### PR TITLE
Based Docker image on alpine linux to fix security issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ LDFLAG_OPTIONS = -ldflags "-X github.com/kubernetes-sigs/federation-v2/pkg/versi
                       -X github.com/kubernetes-sigs/federation-v2/pkg/version.gitCommit=$(GIT_HASH) \
                       -X github.com/kubernetes-sigs/federation-v2/pkg/version.gitTreeState=$(GIT_TREESTATE) \
                       -X github.com/kubernetes-sigs/federation-v2/pkg/version.buildDate=$(BUILDDATE)"
-BUILDCMD_CONTROLLER = go build -o $(CONTROLLER_TARGET) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
+BUILDCMD_CONTROLLER = CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(CONTROLLER_TARGET) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 BUILDCMD_KUBEFED2 = go build -o $(KUBEFED2_TARGET) $(VERBOSE_FLAG) $(LDFLAG_OPTIONS)
 
 BUILD_CONTROLLER = $(BUILDCMD_CONTROLLER) cmd/controller-manager/main.go

--- a/docs/development.md
+++ b/docs/development.md
@@ -262,7 +262,7 @@ Run the following commands using the committed `images/federation-v2/Dockerfile`
 and push a container image to use for deployment:
 
 ```bash
-go build -o images/federation-v2/controller-manager cmd/controller-manager/main.go
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o images/federation-v2/controller-manager cmd/controller-manager/main.go
 docker build images/federation-v2 -t <containerregistry>/<username>/federation-v2:test
 docker push <containerregistry>/<username>/federation-v2:test
 ```

--- a/images/federation-v2/Dockerfile
+++ b/images/federation-v2/Dockerfile
@@ -13,11 +13,9 @@
 # limitations under the License.
 
 
-FROM ubuntu:latest
-RUN apt-get update
-RUN apt-get install -y ca-certificates
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates
 WORKDIR /root/
 COPY /controller-manager .
 ENTRYPOINT ["./controller-manager"]
 CMD ["--install-crds=false"]
-

--- a/scripts/deploy-federation.sh
+++ b/scripts/deploy-federation.sh
@@ -101,7 +101,7 @@ fi
 if [[ ! "${USE_LATEST}" ]]; then
   base_dir="$(cd "$(dirname "$0")/.." ; pwd)"
   dockerfile_dir="${base_dir}/images/federation-v2"
-  go build -o "${dockerfile_dir}"/controller-manager "${base_dir}"/cmd/controller-manager/main.go
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o "${dockerfile_dir}"/controller-manager "${base_dir}"/cmd/controller-manager/main.go
   docker build ${dockerfile_dir} -t "${IMAGE_NAME}"
   ${DOCKER_PUSH_CMD}
 fi


### PR DESCRIPTION
Current `federation-v2` image is based on `ubuntu` and has some security issues has reported in https://quay.io/repository/kubernetes-multicluster/federation-v2/manifest/sha256:033440d719a797cc84a89f849ad58a793273c96d4754f9b7ef650fc10b77c1ec?tab=vulnerabilities
So moving to `alpine`, which is secure and has less size which makes it faster to download.