### PR TITLE
Add the missing test-namespace

### DIFF
--- a/docs/ingressdns-with-externaldns.md
+++ b/docs/ingressdns-with-externaldns.md
@@ -88,7 +88,7 @@ After creating the `IngressDNSRecord`, the DNS Endpoint controller uses the IP a
 populate the `targets` field of the `DNSEndpoint` resource. For example:
 
 ```bash
-$ kubectl get dnsendpoints -o yaml
+$ kubectl -n test-namespace get dnsendpoints -o yaml
 apiVersion: v1
 items:
 - apiVersion: multiclusterdns.federation.k8s.io/v1alpha1


### PR DESCRIPTION
This PR fixes the issue, when user executes command: $ kubectl get dnsendpoints -o yaml.


1. Without the test-namespace, I can't get any information
    $ kubectl get dnsendpoints -o yaml
    apiVersion: v1
    items: []
    kind: List
    metadata:
    resourceVersion: ""
    selfLink: ""

2. Get dnsendpoints from test-namespace
    $ kubectl -n test-namespace get dnsendpoints -o yaml
    apiVersion: v1
    items:

    apiVersion: multiclusterdns.federation.k8s.io/v1alpha1
    kind: DNSEndpoint
    metadata:
    creationTimestamp: "2019-01-18T13:50:25Z"
    generation: 5
    name: ingress-test-ingress
    namespace: test-namespace
    resourceVersion: "965698"
    selfLink: /apis/multiclusterdns.federation.k8s.io/v1alpha1/namespaces/test-namespace/dnsendpoints/ingress-test-ingress
    uid: 01ca464e-1b28-11e9-ab73-a0eb9edce4b4
    spec:
    endpoints:
        dnsName: ingress.example.com
        recordTTL: 300
        recordType: A
        targets:
            172.168.20.0
            192.168.20.0
