### PR TITLE
Make installation compatible with macos under docker 18 with kind.

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -107,6 +107,13 @@ kubectl config use-context cluster1
 You can refer to [helm chart installation guide](https://github.com/kubernetes-sigs/federation-v2/blob/master/charts/federation-v2/README.md)
 to install and uninstall a federation-v2 control plane.
 
+### Fix Cluster Registry meta (Optional)
+Cluster registry meta-data address need to be fixed if you are running hyperkit docker under `Darwin`. Run following script to fix this.
+Specify the clusters you need to be fixed, Comma seperated.
+```bash
+./scripts/fix-joined-kind-clusters.sh cluster1,cluster2
+``` 
+
 ## Operations
 
 ### Join Clusters

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -29,6 +29,7 @@ NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 OVERWRITE_KUBECONFIG="${OVERWRITE_KUBECONFIG:-}"
 docker_daemon_config="/etc/docker/daemon.json"
 kubeconfig="${HOME}/.kube/config"
+OS=`uname`
 
 function create-insecure-registry() {
   # Run insecure registry as container
@@ -129,20 +130,23 @@ function fixup-cluster() {
   # TODO(font): Need to set container IP address in order for clusters to reach
   # kube API servers in other clusters until
   # https://github.com/kubernetes-sigs/kind/issues/111 is resolved.
-  local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster${i}-control-plane)
-  # Using the container ip allows the use of port 6443 instead of the
-  # random port intended to be exposed on localhost.
-  sed -i "s/localhost.*$/${container_ip_addr}:6443/" ${kubeconfig_path}
+  if [ "$OS" != "Darwin" ];then
+      local container_ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' cluster${i}-control-plane)
+      # Using the container ip allows the use of port 6443 instead of the
+      # random port intended to be exposed on localhost.
+      sed -i.bak "s/localhost.*$/${container_ip_addr}:6443/" ${kubeconfig_path}&& rm -rf ${kubeconfig_path}.bak
+  fi
 
   # TODO(font): Need to rename auth user name to avoid conflicts when using
   # multiple cluster kubeconfigs. Remove once
   # https://github.com/kubernetes-sigs/kind/issues/112 is resolved.
-  sed -i "s/kubernetes-admin/kubernetes-cluster${i}-admin/" ${kubeconfig_path}
+  sed -i.bak "s/kubernetes-admin/kubernetes-cluster${i}-admin/" ${kubeconfig_path} && rm -rf ${kubeconfig_path}.bak
 }
 
 function check-clusters-ready() {
   for i in $(seq ${1}); do
-    util::wait-for-condition 'ok' "kubectl --context cluster${i} get --raw=/healthz &> /dev/null" 120
+    local kubeconfig_path="$(kind get kubeconfig-path --name cluster${i})"
+    util::wait-for-condition 'ok' "kubectl --kubeconfig ${kubeconfig_path} --context cluster${i} get --raw=/healthz &> /dev/null" 120
   done
 }
 

--- a/scripts/fix-joined-kind-clusters.sh
+++ b/scripts/fix-joined-kind-clusters.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+
+if [ "$1" == "" ];then
+    echo "kubernetes cluster context list need to be provided. eg. cluster1,cluster2,cluster3"; exit 1
+fi
+CLUSTER_CONTEXT=${1//,/ }
+
+if [ "`uname`" == 'Darwin' ];then
+
+    # We need to fix cluster ip addr in cluster-registry for mac os.
+    # Assume all context was contained in current kubeconfig.
+    for c in ${CLUSTER_CONTEXT};
+    do
+        ip_addr=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${c}-control-plane)
+
+        kubectl patch clusters -n kube-multicluster-public ${c} --type merge \
+            --patch "{\"spec\":{\"kubernetesApiEndpoints\":{\"serverEndpoints\":[{\"clientCIDR\":\"0.0.0.0/0\", \"serverAddress\":\"https://${ip_addr}:6443\"}]}}}"
+    done
+fi
+
+echo "cluster $1 address patched successfully."


### PR DESCRIPTION
Found some tiny problems when deploy with MacOS.
1. `sed` in place is not compatible with MacOS.
2. create cluster with `kind` name error. should prefix with `kind` as the context showed.
3. Fix cluster.registry address, change from `localhost` to `container ip address`.

Signed-off-by: Aoxn <yaoyao.aoxn@hotmail.com>