### PR TITLE
Align FederationConfig API with K8s API conventions

### DIFF
--- a/charts/kubefed/README.md
+++ b/charts/kubefed/README.md
@@ -134,7 +134,7 @@ chart and their default values.
 | controllermanager.clusterHealthCheckFailureThreshold | Minimum consecutive failures for the cluster health to be considered failed after having succeeded.                                                                          | 3                               |
 | controllermanager.clusterHealthCheckSuccessThreshold | Minimum consecutive successes for the cluster health to be considered successful after having failed.                                                                        | 1                               |
 | controllermanager.clusterHealthCheckTimeoutSeconds   | Number of seconds after which the cluster health check times out.                                                                                                            | 3                               |
-| controllermanager.syncController.skipAdoptingResources  | Whether to skip adopting pre-existing resource in member clusters.                                                                                                        | false                           |
+| controllermanager.syncController.adoptResources  | Whether to adopt pre-existing resource in member clusters.                                                                                                        		          | Enabled                         |
 | global.scope                   | Whether the kubefed namespace will be the only target for federation.                                                                                                                           | Cluster                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to

--- a/charts/kubefed/charts/controllermanager/templates/crds.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/crds.yaml
@@ -424,12 +424,113 @@ spec:
           type: object
         spec:
           properties:
+            clusterHealthCheck:
+              properties:
+                failureThreshold:
+                  description: Minimum consecutive failures for the cluster health
+                    to be considered failed after having succeeded.
+                  format: int64
+                  type: integer
+                periodSeconds:
+                  description: How often to monitor the cluster health (in seconds).
+                  format: int64
+                  type: integer
+                successThreshold:
+                  description: Minimum consecutive successes for the cluster health
+                    to be considered successful after having failed.
+                  format: int64
+                  type: integer
+                timeoutSeconds:
+                  description: Number of seconds after which the cluster health check
+                    times out.
+                  format: int64
+                  type: integer
+              required:
+              - periodSeconds
+              - failureThreshold
+              - successThreshold
+              - timeoutSeconds
+              type: object
+            controllerDuration:
+              properties:
+                availableDelay:
+                  description: Time to wait before reconciling on a healthy cluster.
+                  type: string
+                unavailableDelay:
+                  description: Time to wait before giving up on an unhealthy cluster.
+                  type: string
+              required:
+              - availableDelay
+              - unavailableDelay
+              type: object
+            featureGates:
+              items:
+                properties:
+                  configuration:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - name
+                - configuration
+                type: object
+              type: array
+            leaderElect:
+              properties:
+                leaseDuration:
+                  description: The duration that non-leader candidates will wait after
+                    observing a leadership renewal until attempting to acquire leadership
+                    of a led but unrenewed leader slot. This is effectively the maximum
+                    duration that a leader can be stopped before it is replaced by
+                    another candidate. This is only applicable if leader election
+                    is enabled.
+                  type: string
+                renewDeadline:
+                  description: The interval between attempts by the acting master
+                    to renew a leadership slot before it stops leading. This must
+                    be less than or equal to the lease duration. This is only applicable
+                    if leader election is enabled.
+                  type: string
+                resourceLock:
+                  description: The type of resource object that is used for locking
+                    during leader election. Supported options are `configmaps` (default)
+                    and `endpoints`.
+                  type: string
+                retryPeriod:
+                  description: The duration the clients should wait between attempting
+                    acquisition and renewal of a leadership. This is only applicable
+                    if leader election is enabled.
+                  type: string
+              required:
+              - leaseDuration
+              - renewDeadline
+              - retryPeriod
+              - resourceLock
+              type: object
             scope:
               description: The scope of the kubefed control plane should be either
                 `Namespaced` or `Cluster`. `Namespaced` indicates that the kubefed
                 namespace will be the only target for federation.
               type: string
+            syncController:
+              properties:
+                adoptResources:
+                  description: Whether to adopt pre-existing resources in member clusters.
+                    Defaults to "Enabled".
+                  type: string
+              required:
+              - adoptResources
+              type: object
+          required:
+          - scope
+          - controllerDuration
+          - leaderElect
+          - featureGates
+          - clusterHealthCheck
+          - syncController
           type: object
+      required:
+      - spec
   version: v1alpha1
 status:
   acceptedNames:

--- a/charts/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
@@ -5,22 +5,22 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   scope: {{ .Values.global.scope | default "Cluster" | quote }}
-  controller-duration:
-    available-delay: {{ .Values.clusterAvailableDelay | default "20s" | quote }}
-    unavailable-delay: {{ .Values.clusterUnavailableDelay | default "60s" | quote }}
-  leader-elect:
-    lease-duration: {{ .Values.leaderElectLeaseDuration | default "15s" | quote }}
-    renew-deadline: {{ .Values.leaderElectRenewDeadline | default "10s" | quote }}
-    retry-period: {{ .Values.leaderElectRetryPeriod | default "5s" | quote }}
-    resource-lock: {{ .Values.leaderElectResourceLock | default "configmaps" | quote }}
-  cluster-health-check:
-    period-seconds: {{ .Values.clusterHealthCheckPeriodSeconds | default 10 }}
-    failure-threshold: {{ .Values.clusterHealthCheckFailureThreshold | default 3 }}
-    success-threshold: {{ .Values.clusterHealthCheckSuccessThreshold | default 1 }}
-    timeout-seconds: {{ .Values.clusterHealthCheckTimeoutSeconds | default 3 }}
-  sync-controller:
-    skip-adopting-resources: {{ .Values.syncController.skipAdoptingResources | default false }}
-  feature-gates:
+  controllerDuration:
+    availableDelay: {{ .Values.clusterAvailableDelay | default "20s" | quote }}
+    unavailableDelay: {{ .Values.clusterUnavailableDelay | default "60s" | quote }}
+  leaderElect:
+    leaseDuration: {{ .Values.leaderElectLeaseDuration | default "15s" | quote }}
+    renewDeadline: {{ .Values.leaderElectRenewDeadline | default "10s" | quote }}
+    retryPeriod: {{ .Values.leaderElectRetryPeriod | default "5s" | quote }}
+    resourceLock: {{ .Values.leaderElectResourceLock | default "configmaps" | quote }}
+  clusterHealthCheck:
+    periodSeconds: {{ .Values.clusterHealthCheckPeriodSeconds | default 10 }}
+    failureThreshold: {{ .Values.clusterHealthCheckFailureThreshold | default 3 }}
+    successThreshold: {{ .Values.clusterHealthCheckSuccessThreshold | default 1 }}
+    timeoutSeconds: {{ .Values.clusterHealthCheckTimeoutSeconds | default 3 }}
+  syncController:
+    skipAdoptingResources: {{ .Values.syncController.skipAdoptingResources | default false }}
+  featureGates:
 {{- if .Values.featureGates }}
   - name: PushReconciler
     enabled: {{ .Values.featureGates.PushReconciler | default true }}

--- a/charts/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/kubefedconfig.yaml
@@ -19,15 +19,15 @@ spec:
     successThreshold: {{ .Values.clusterHealthCheckSuccessThreshold | default 1 }}
     timeoutSeconds: {{ .Values.clusterHealthCheckTimeoutSeconds | default 3 }}
   syncController:
-    skipAdoptingResources: {{ .Values.syncController.skipAdoptingResources | default false }}
+    adoptResources: {{ .Values.syncController.adoptResources | default "Enabled" | quote }}
   featureGates:
 {{- if .Values.featureGates }}
   - name: PushReconciler
-    enabled: {{ .Values.featureGates.PushReconciler | default true }}
+    configuration: {{ .Values.featureGates.PushReconciler | default "Enabled" | quote }}
   - name: SchedulerPreferences
-    enabled: {{ .Values.featureGates.SchedulerPreferences | default true }}
+    configuration: {{ .Values.featureGates.SchedulerPreferences | default "Enabled" | quote }}
   - name: CrossClusterServiceDiscovery
-    enabled: {{ .Values.featureGates.CrossClusterServiceDiscovery | default true }}
+    configuration: {{ .Values.featureGates.CrossClusterServiceDiscovery | default "Enabled" | quote }}
   - name: FederatedIngress
-    enabled: {{ .Values.featureGates.FederatedIngress | default true }}
+    configuration: {{ .Values.featureGates.FederatedIngress | default "Enabled" | quote }}
 {{- end }}

--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -30,8 +30,8 @@ controllermanager:
   ## Supported options are `configmaps` and `endpoints`
   leaderElectResourceLock:
   syncController:
-    skipAdoptingResources:
-  ## Value of feature gates item should be either `true` or `false`
+    adoptResources:
+  ## Value of feature gates item should be either `Enabled` or `Disabled`
   featureGates:
     PushReconciler:
     SchedulerPreferences:

--- a/cmd/controller-manager/app/leaderelection/leaderelection.go
+++ b/cmd/controller-manager/app/leaderelection/leaderelection.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"os"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	kubeclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -52,7 +52,7 @@ func NewFederationLeaderElector(opts *options.Options, fnStartControllers func(*
 
 	// add a uniquifier so that two processes on the same host don't accidentally both become active
 	id := hostname + "_" + string(uuid.NewUUID())
-	rl, err := resourcelock.New(opts.LeaderElection.ResourceLock,
+	rl, err := resourcelock.New(string(opts.LeaderElection.ResourceLock),
 		opts.Config.KubefedNamespace,
 		component,
 		leaderElectionClient.CoreV1(),

--- a/cmd/controller-manager/app/options/options.go
+++ b/cmd/controller-manager/app/options/options.go
@@ -31,7 +31,7 @@ type Options struct {
 	FeatureGates             map[string]bool
 	Scope                    apiextv1b1.ResourceScope
 	LeaderElection           *util.LeaderElectionConfiguration
-	ClusterHealthCheckConfig util.ClusterHealthCheckConfig
+	ClusterHealthCheckConfig *util.ClusterHealthCheckConfig
 }
 
 // AddFlags adds flags to fs and binds them to options.
@@ -41,8 +41,9 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 
 func NewOptions() *Options {
 	return &Options{
-		Config:         new(util.ControllerConfig),
-		FeatureGates:   make(map[string]bool),
-		LeaderElection: new(util.LeaderElectionConfiguration),
+		Config:                   new(util.ControllerConfig),
+		FeatureGates:             make(map[string]bool),
+		LeaderElection:           new(util.LeaderElectionConfiguration),
+		ClusterHealthCheckConfig: new(util.ClusterHealthCheckConfig),
 	}
 }

--- a/config/kubefedconfig.yaml
+++ b/config/kubefedconfig.yaml
@@ -8,3 +8,12 @@ spec:
     leaseDuration: 1500ms
     renewDeadline: 1000ms
     retryPeriod: 500ms
+  featureGates:
+  - name: PushReconciler
+    configuration: "Enabled"
+  - name: SchedulerPreferences
+    configuration: "Enabled"
+  - name: CrossClusterServiceDiscovery
+    configuration: "Enabled"
+  - name: FederatedIngress
+    configuration: "Enabled"

--- a/config/kubefedconfig.yaml
+++ b/config/kubefedconfig.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kubefed
   namespace: kube-federation-system
 spec:
-  leader-elect:
-    lease-duration: 1500ms
-    renew-deadline: 1000ms
-    retry-period: 500ms
+  leaderElect:
+    leaseDuration: 1500ms
+    renewDeadline: 1000ms
+    retryPeriod: 500ms

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -395,7 +395,7 @@ The following table enumerates the possible values for cluster status:
 
 | Status                 | Description                  |
 |------------------------|------------------------------|
-| AlreadyExists          | The target resource already exists in the cluster, and cannot be adopted due to `skipAdoptingResources` being configured. |
+| AlreadyExists          | The target resource already exists in the cluster, and cannot be adopted due to `adoptResources` being disabled. |
 | CachedRetrievalFailed  | An error occurred when retrieving the cached target resource. |
 | ClientRetrievalFailed  | An error occurred while attempting to create an API client for the member cluster. |
 | ClusterNotReady        | The latest health check for the cluster did not succeed. |

--- a/example/config/kubefedconfig.yaml
+++ b/example/config/kubefedconfig.yaml
@@ -5,16 +5,16 @@ metadata:
   namespace: kube-federation-system
 spec:
   scope: Cluster
-  controller-duration:
-    available-delay: 20s
-    unavailable-delay: 60s
-    cluster-monitor-period: 40s
-  leader-elect:
-    lease-duration: 15s
-    renew-deadline: 10s
-    retry-period: 5s
-    resource-lock: configmaps
-  feature-gates:
+  controllerDuration:
+    availableDelay: 20s
+    unavailableDelay: 60s
+    clusterMonitorPeriod: 40s
+  leaderElect:
+    leaseDuration: 15s
+    renewDeadline: 10s
+    retryPeriod: 5s
+    resourceLock: configmaps
+  featureGates:
   - name: PushReconciler
     enabled: true
   - name: SchedulerPreferences

--- a/pkg/apis/core/v1alpha1/kubefedconfig_types.go
+++ b/pkg/apis/core/v1alpha1/kubefedconfig_types.go
@@ -25,19 +25,19 @@ import (
 type KubefedConfigSpec struct {
 	// The scope of the kubefed control plane should be either `Namespaced` or `Cluster`.
 	// `Namespaced` indicates that the kubefed namespace will be the only target for federation.
-	Scope              apiextv1b1.ResourceScope `json:"scope,omitempty"`
-	ControllerDuration DurationConfig           `json:"controllerDuration,omitempty"`
-	LeaderElect        LeaderElectConfig        `json:"leaderElect,omitempty"`
-	FeatureGates       []FeatureGatesConfig     `json:"featureGates,omitempty"`
-	ClusterHealthCheck ClusterHealthCheckConfig `json:"clusterHealthCheck,omitempty"`
-	SyncController     SyncControllerConfig     `json:"syncController,omitempty"`
+	Scope              apiextv1b1.ResourceScope `json:"scope"`
+	ControllerDuration DurationConfig           `json:"controllerDuration"`
+	LeaderElect        LeaderElectConfig        `json:"leaderElect"`
+	FeatureGates       []FeatureGatesConfig     `json:"featureGates"`
+	ClusterHealthCheck ClusterHealthCheckConfig `json:"clusterHealthCheck"`
+	SyncController     SyncControllerConfig     `json:"syncController"`
 }
 
 type DurationConfig struct {
 	// Time to wait before reconciling on a healthy cluster.
-	AvailableDelay metav1.Duration `json:"availableDelay,omitempty"`
+	AvailableDelay metav1.Duration `json:"availableDelay"`
 	// Time to wait before giving up on an unhealthy cluster.
-	UnavailableDelay metav1.Duration `json:"unavailableDelay,omitempty"`
+	UnavailableDelay metav1.Duration `json:"unavailableDelay"`
 }
 type LeaderElectConfig struct {
 	// The duration that non-leader candidates will wait after observing a leadership
@@ -45,38 +45,61 @@ type LeaderElectConfig struct {
 	// slot. This is effectively the maximum duration that a leader can be stopped
 	// before it is replaced by another candidate. This is only applicable if leader
 	// election is enabled.
-	LeaseDuration metav1.Duration `json:"leaseDuration,omitempty"`
+	LeaseDuration metav1.Duration `json:"leaseDuration"`
 	// The interval between attempts by the acting master to renew a leadership slot
 	// before it stops leading. This must be less than or equal to the lease duration.
 	// This is only applicable if leader election is enabled.
-	RenewDeadline metav1.Duration `json:"renewDeadline,omitempty"`
+	RenewDeadline metav1.Duration `json:"renewDeadline"`
 	// The duration the clients should wait between attempting acquisition and renewal
 	// of a leadership. This is only applicable if leader election is enabled.
-	RetryPeriod metav1.Duration `json:"retryPeriod,omitempty"`
+	RetryPeriod metav1.Duration `json:"retryPeriod"`
 	// The type of resource object that is used for locking during
 	// leader election. Supported options are `configmaps` (default) and `endpoints`.
-	ResourceLock string `json:"resourceLock,omitempty"`
+	ResourceLock ResourceLockType `json:"resourceLock"`
 }
+
+type ResourceLockType string
+
+const (
+	ConfigMapsResourceLock ResourceLockType = "configmaps"
+	EndpointsResourceLock  ResourceLockType = "endpoints"
+)
+
 type FeatureGatesConfig struct {
-	Name    string `json:"name,omitempty"`
-	Enabled bool   `json:"enabled,omitempty"`
+	Name          string            `json:"name"`
+	Configuration ConfigurationMode `json:"configuration"`
 }
+
+type ConfigurationMode string
+
+const (
+	ConfigurationEnabled  ConfigurationMode = "Enabled"
+	ConfigurationDisabled ConfigurationMode = "Disabled"
+)
 
 type ClusterHealthCheckConfig struct {
 	// How often to monitor the cluster health (in seconds).
-	PeriodSeconds int `json:"periodSeconds,omitempty"`
+	PeriodSeconds int64 `json:"periodSeconds"`
 	// Minimum consecutive failures for the cluster health to be considered failed after having succeeded.
-	FailureThreshold int `json:"failureThreshold,omitempty"`
+	FailureThreshold int64 `json:"failureThreshold"`
 	// Minimum consecutive successes for the cluster health to be considered successful after having failed.
-	SuccessThreshold int `json:"successThreshold,omitempty"`
+	SuccessThreshold int64 `json:"successThreshold"`
 	// Number of seconds after which the cluster health check times out.
-	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
+	TimeoutSeconds int64 `json:"timeoutSeconds"`
 }
 
 type SyncControllerConfig struct {
-	// Whether to skip adopting pre-existing resource in member clusters. Defaults to false
-	SkipAdoptingResources bool `json:"skipAdoptingResources,omitempty"`
+	// Whether to adopt pre-existing resources in member clusters. Defaults to
+	// "Enabled".
+	AdoptResources ResourceAdoption `json:"adoptResources"`
 }
+
+type ResourceAdoption string
+
+const (
+	AdoptResourcesEnabled  ResourceAdoption = "Enabled"
+	AdoptResourcesDisabled ResourceAdoption = "Disabled"
+)
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -88,7 +111,7 @@ type KubefedConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec KubefedConfigSpec `json:"spec,omitempty"`
+	Spec KubefedConfigSpec `json:"spec"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/core/v1alpha1/kubefedconfig_types.go
+++ b/pkg/apis/core/v1alpha1/kubefedconfig_types.go
@@ -26,18 +26,18 @@ type KubefedConfigSpec struct {
 	// The scope of the kubefed control plane should be either `Namespaced` or `Cluster`.
 	// `Namespaced` indicates that the kubefed namespace will be the only target for federation.
 	Scope              apiextv1b1.ResourceScope `json:"scope,omitempty"`
-	ControllerDuration DurationConfig           `json:"controller-duration,omitempty"`
-	LeaderElect        LeaderElectConfig        `json:"leader-elect,omitempty"`
-	FeatureGates       []FeatureGatesConfig     `json:"feature-gates,omitempty"`
-	ClusterHealthCheck ClusterHealthCheckConfig `json:"cluster-health-check,omitempty"`
-	SyncController     SyncControllerConfig     `json:"sync-controller,omitempty"`
+	ControllerDuration DurationConfig           `json:"controllerDuration,omitempty"`
+	LeaderElect        LeaderElectConfig        `json:"leaderElect,omitempty"`
+	FeatureGates       []FeatureGatesConfig     `json:"featureGates,omitempty"`
+	ClusterHealthCheck ClusterHealthCheckConfig `json:"clusterHealthCheck,omitempty"`
+	SyncController     SyncControllerConfig     `json:"syncController,omitempty"`
 }
 
 type DurationConfig struct {
 	// Time to wait before reconciling on a healthy cluster.
-	AvailableDelay metav1.Duration `json:"available-delay,omitempty"`
+	AvailableDelay metav1.Duration `json:"availableDelay,omitempty"`
 	// Time to wait before giving up on an unhealthy cluster.
-	UnavailableDelay metav1.Duration `json:"unavailable-delay,omitempty"`
+	UnavailableDelay metav1.Duration `json:"unavailableDelay,omitempty"`
 }
 type LeaderElectConfig struct {
 	// The duration that non-leader candidates will wait after observing a leadership
@@ -45,17 +45,17 @@ type LeaderElectConfig struct {
 	// slot. This is effectively the maximum duration that a leader can be stopped
 	// before it is replaced by another candidate. This is only applicable if leader
 	// election is enabled.
-	LeaseDuration metav1.Duration `json:"lease-duration,omitempty"`
+	LeaseDuration metav1.Duration `json:"leaseDuration,omitempty"`
 	// The interval between attempts by the acting master to renew a leadership slot
 	// before it stops leading. This must be less than or equal to the lease duration.
 	// This is only applicable if leader election is enabled.
-	RenewDeadline metav1.Duration `json:"renew-deadline,omitempty"`
+	RenewDeadline metav1.Duration `json:"renewDeadline,omitempty"`
 	// The duration the clients should wait between attempting acquisition and renewal
 	// of a leadership. This is only applicable if leader election is enabled.
-	RetryPeriod metav1.Duration `json:"retry-period,omitempty"`
+	RetryPeriod metav1.Duration `json:"retryPeriod,omitempty"`
 	// The type of resource object that is used for locking during
 	// leader election. Supported options are `configmaps` (default) and `endpoints`.
-	ResourceLock string `json:"resource-lock,omitempty"`
+	ResourceLock string `json:"resourceLock,omitempty"`
 }
 type FeatureGatesConfig struct {
 	Name    string `json:"name,omitempty"`
@@ -64,18 +64,18 @@ type FeatureGatesConfig struct {
 
 type ClusterHealthCheckConfig struct {
 	// How often to monitor the cluster health (in seconds).
-	PeriodSeconds int `json:"period-seconds,omitempty"`
+	PeriodSeconds int `json:"periodSeconds,omitempty"`
 	// Minimum consecutive failures for the cluster health to be considered failed after having succeeded.
-	FailureThreshold int `json:"failure-threshold,omitempty"`
+	FailureThreshold int `json:"failureThreshold,omitempty"`
 	// Minimum consecutive successes for the cluster health to be considered successful after having failed.
-	SuccessThreshold int `json:"success-threshold,omitempty"`
+	SuccessThreshold int `json:"successThreshold,omitempty"`
 	// Number of seconds after which the cluster health check times out.
-	TimeoutSeconds int `json:"timeout-seconds,omitempty"`
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 }
 
 type SyncControllerConfig struct {
 	// Whether to skip adopting pre-existing resource in member clusters. Defaults to false
-	SkipAdoptingResources bool `json:"skip-adopting-resources,omitempty"`
+	SkipAdoptingResources bool `json:"skipAdoptingResources,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/kubefedcluster/controller.go
+++ b/pkg/controller/kubefedcluster/controller.go
@@ -44,7 +44,7 @@ type ClusterData struct {
 	clusterStatus *fedv1a1.KubefedClusterStatus
 
 	// How many times in a row the probe has returned the same result.
-	resultRun int
+	resultRun int64
 }
 
 // ClusterController is responsible for maintaining the health status of each
@@ -53,7 +53,7 @@ type ClusterController struct {
 	client genericclient.Client
 
 	// clusterHealthCheckConfig is the configurable parameters for cluster health check
-	clusterHealthCheckConfig util.ClusterHealthCheckConfig
+	clusterHealthCheckConfig *util.ClusterHealthCheckConfig
 
 	mu sync.RWMutex
 
@@ -70,7 +70,7 @@ type ClusterController struct {
 }
 
 // StartClusterController starts a new cluster controller.
-func StartClusterController(config *util.ControllerConfig, clusterHealthCheckConfig util.ClusterHealthCheckConfig, stopChan <-chan struct{}) error {
+func StartClusterController(config *util.ControllerConfig, clusterHealthCheckConfig *util.ClusterHealthCheckConfig, stopChan <-chan struct{}) error {
 	controller, err := newClusterController(config, clusterHealthCheckConfig)
 	if err != nil {
 		return err
@@ -81,7 +81,7 @@ func StartClusterController(config *util.ControllerConfig, clusterHealthCheckCon
 }
 
 // newClusterController returns a new cluster controller
-func newClusterController(config *util.ControllerConfig, clusterHealthCheckConfig util.ClusterHealthCheckConfig) (*ClusterController, error) {
+func newClusterController(config *util.ControllerConfig, clusterHealthCheckConfig *util.ClusterHealthCheckConfig) (*ClusterController, error) {
 	kubeConfig := restclient.CopyConfig(config.KubeConfig)
 	kubeConfig.Timeout = time.Duration(clusterHealthCheckConfig.TimeoutSeconds) * time.Second
 	client := genericclient.NewForConfigOrDieWithUserAgent(kubeConfig, "cluster-controller")
@@ -194,7 +194,7 @@ func (cc *ClusterController) updateIndividualClusterStatus(cluster *fedv1a1.Kube
 }
 
 func thresholdAdjustedClusterStatus(clusterStatus *fedv1a1.KubefedClusterStatus, storedData *ClusterData,
-	clusterHealthCheckConfig util.ClusterHealthCheckConfig) *fedv1a1.KubefedClusterStatus {
+	clusterHealthCheckConfig *util.ClusterHealthCheckConfig) *fedv1a1.KubefedClusterStatus {
 
 	if storedData.clusterStatus == nil {
 		storedData.resultRun = 1

--- a/pkg/controller/kubefedcluster/controller_test.go
+++ b/pkg/controller/kubefedcluster/controller_test.go
@@ -38,7 +38,7 @@ func TestThresholdCheckedClusterStatus(t *testing.T) {
 	t4 := metav1.Time{Time: epoch.Add(4 * time.Second)}
 	t5 := metav1.Time{Time: epoch.Add(5 * time.Second)}
 
-	config := util.ClusterHealthCheckConfig{
+	config := &util.ClusterHealthCheckConfig{
 		PeriodSeconds:    10,
 		FailureThreshold: 3,
 		SuccessThreshold: 1,
@@ -49,7 +49,7 @@ func TestThresholdCheckedClusterStatus(t *testing.T) {
 		clusterStatus         *fedv1a1.KubefedClusterStatus
 		storedClusterData     *ClusterData
 		expectedClusterStatus *fedv1a1.KubefedClusterStatus
-		expectedResultRun     int
+		expectedResultRun     int64
 	}{
 		"ClusterReadyAtBegining": {
 			clusterStatus:         clusterStatus(corev1.ConditionTrue, t1, t1),

--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -43,7 +43,7 @@ const (
 	DefaultLeaderElectionLeaseDuration = 15 * time.Second
 	DefaultLeaderElectionRenewDeadline = 10 * time.Second
 	DefaultLeaderElectionRetryPeriod   = 5 * time.Second
-	DefaultLeaderElectionResourceLock  = "configmaps"
+	DefaultLeaderElectionResourceLock  = fedv1a1.ConfigMapsResourceLock
 
 	DefaultClusterHealthCheckPeriod           = 10
 	DefaultClusterHealthCheckFailureThreshold = 3

--- a/pkg/controller/util/controllerconfig.go
+++ b/pkg/controller/util/controllerconfig.go
@@ -21,6 +21,8 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
+
+	fedv1a1 "sigs.k8s.io/kubefed/pkg/apis/core/v1alpha1"
 )
 
 // LeaderElectionConfiguration defines the configuration of leader election
@@ -44,7 +46,7 @@ type LeaderElectionConfiguration struct {
 	RetryPeriod time.Duration
 	// resourceLock indicates the resource object type that will be used to lock
 	// during leader election cycles.
-	ResourceLock string
+	ResourceLock fedv1a1.ResourceLockType
 }
 
 // KubefedNamespaces defines the namespace configuration shared by
@@ -56,10 +58,10 @@ type KubefedNamespaces struct {
 
 // ClusterHealthCheckConfig defines the configurable parameters for cluster health check
 type ClusterHealthCheckConfig struct {
-	PeriodSeconds    int
-	FailureThreshold int
-	SuccessThreshold int
-	TimeoutSeconds   int
+	PeriodSeconds    int64
+	FailureThreshold int64
+	SuccessThreshold int64
+	TimeoutSeconds   int64
 }
 
 // ControllerConfig defines the configuration common to federation

--- a/test/e2e/framework/controller.go
+++ b/test/e2e/framework/controller.go
@@ -106,7 +106,7 @@ func NewClusterControllerFixture(tl common.TestLogger, config *util.ControllerCo
 	f := &ControllerFixture{
 		stopChan: make(chan struct{}),
 	}
-	clusterHealthCheckConfig := util.ClusterHealthCheckConfig{PeriodSeconds: 1, FailureThreshold: 1}
+	clusterHealthCheckConfig := &util.ClusterHealthCheckConfig{PeriodSeconds: 1, FailureThreshold: 1}
 	err := kubefedcluster.StartClusterController(config, clusterHealthCheckConfig, f.stopChan)
 	if err != nil {
 		tl.Fatalf("Error starting cluster controller: %v", err)


### PR DESCRIPTION
Partial fix for #879 .

**NOTE:** Due to the K8s API conventions doc being ambiguous over the use of pointers for optional fields, I have kept optional fields without a built-in `nil` value as non-pointers for now. This is subject to change pending a more formal API review.