### PR TITLE
Run E2E with travis in forked repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,25 +122,25 @@ push: container
 
 	if [[ -z "$(TRAVIS_PULL_REQUEST)" ]]; \
 	then \
-		$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_VERSION); \
+		$(DOCKER) push $(IMAGE):$(GIT_VERSION); \
 	elif [[ "$(TRAVIS_PULL_REQUEST)" == "false" && "$(TRAVIS_SECURE_ENV_VARS)" == "true" ]]; \
 	then \
 		$(DOCKER) login -u "$(QUAY_USERNAME)" -p "$(QUAY_PASSWORD)" quay.io; \
 		if [[ "$(TRAVIS_BRANCH)" == "master" ]]; \
 		then \
-			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):canary; \
-			$(DOCKER) push $(REGISTRY)/$(TARGET):canary; \
+			$(DOCKER) tag $(IMAGE):$(GIT_VERSION) $(IMAGE):canary; \
+			$(DOCKER) push $(IMAGE):canary; \
 		fi; \
 		\
 		if git describe --tags --exact-match >/dev/null 2>&1; \
 		then \
-			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):$(GIT_TAG); \
-			$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_TAG); \
-			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):latest; \
-			$(DOCKER) push $(REGISTRY)/$(TARGET):latest; \
+			$(DOCKER) tag $(IMAGE):$(GIT_VERSION) $(IMAGE):$(GIT_TAG); \
+			$(DOCKER) push $(IMAGE):$(GIT_TAG); \
+			$(DOCKER) tag $(IMAGE):$(GIT_VERSION) $(IMAGE):latest; \
+			$(DOCKER) push $(IMAGE):latest; \
 		fi \
 	fi
 
 clean:
 	rm -f $(ALL_BINS)
-	$(DOCKER) rmi $(REGISTRY)/$(TARGET):$(GIT_VERSION) || true
+	$(DOCKER) rmi $(IMAGE):$(GIT_VERSION) || true

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := /bin/bash
 TARGET = kubefed
 GOTARGET = sigs.k8s.io/$(TARGET)
 REGISTRY ?= quay.io/kubernetes-multicluster
@@ -119,13 +120,13 @@ generate: generate-code kubefedctl
 
 push: container
 
-	if [ -z "$(TRAVIS_PULL_REQUEST)" ]; \
+	if [[ -z "$(TRAVIS_PULL_REQUEST)" ]]; \
 	then \
 		$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_VERSION); \
-	elif [ "$(TRAVIS_PULL_REQUEST)" = "false" && "$(TRAVIS_SECURE_ENV_VARS)" = "true" ]; \
+	elif [[ "$(TRAVIS_PULL_REQUEST)" == "false" && "$(TRAVIS_SECURE_ENV_VARS)" == "true" ]]; \
 	then \
 		$(DOCKER) login -u "$(QUAY_USERNAME)" -p "$(QUAY_PASSWORD)" quay.io; \
-		if [ "$(TRAVIS_BRANCH)" = "master" ]; \
+		if [[ "$(TRAVIS_BRANCH)" == "master" ]]; \
 		then \
 			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):canary; \
 			$(DOCKER) push $(REGISTRY)/$(TARGET):canary; \

--- a/Makefile
+++ b/Makefile
@@ -122,22 +122,22 @@ push: container
 	if [ -z "$(TRAVIS_PULL_REQUEST)" ]; \
 	then \
 		$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_VERSION); \
-	elif [ "$(TRAVIS_PULL_REQUEST)" = "false" ]; \
+	elif [ "$(TRAVIS_PULL_REQUEST)" = "false" && "$(TRAVIS_SECURE_ENV_VARS)" = "true" ]; \
 	then \
 		$(DOCKER) login -u "$(QUAY_USERNAME)" -p "$(QUAY_PASSWORD)" quay.io; \
 		if [ "$(TRAVIS_BRANCH)" = "master" ]; \
 		then \
 			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):canary; \
 			$(DOCKER) push $(REGISTRY)/$(TARGET):canary; \
+		fi; \
+		\
+		if git describe --tags --exact-match >/dev/null 2>&1; \
+		then \
+			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):$(GIT_TAG); \
+			$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_TAG); \
+			$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):latest; \
+			$(DOCKER) push $(REGISTRY)/$(TARGET):latest; \
 		fi \
-	fi
-
-	if git describe --tags --exact-match >/dev/null 2>&1; \
-	then \
-		$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):$(GIT_TAG); \
-		$(DOCKER) push $(REGISTRY)/$(TARGET):$(GIT_TAG); \
-		$(DOCKER) tag $(REGISTRY)/$(TARGET):$(GIT_VERSION) $(REGISTRY)/$(TARGET):latest; \
-		$(DOCKER) push $(REGISTRY)/$(TARGET):latest; \
 	fi
 
 clean:


### PR DESCRIPTION
This prevents running `docker login` using the quay credentials if we don't have any travis secure environment vars set e.g. running travis in forked repos.