### PR TITLE
Rename Federation V2 to KubeFed in all docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,17 @@
 ## Contributing Guidelines
-This repo contains an alpha release of some of the foundational aspects of V2 of Kubernetes Federation. All the contribution is done via GitHub. Please also read the contributors guide: https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
+This repo contains an alpha release of some of the foundational aspects of Kubernetes Cluster Federation. All the contribution is done via GitHub. Please also read the contributors guide: https://github.com/kubernetes/community/blob/master/contributors/guide/README.md
 
 ## Sign the CLA
 Kubernetes projects require that you sign a Contributor License Agreement (CLA) before we can accept your pull requests. Please see https://github.com/kubernetes/community/blob/master/CLA.md for more information
 
 ## Learn About Kubernetes Cluster Federation
-If you want to learn about Kubernetes Cluster Federation, please read through the doc:
-https://github.com/kubernetes-sigs/kubefed#kubernetes-cluster-federation
+If you want to learn about KubeFed, please read through the doc:
+https://github.com/kubernetes-sigs/kubefed#kubefed
 
 To learn how to use Kubernetes Cluster Federation, please read through the User Guide:
 https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md
 
-If you are interested in contributing to Kubernetes Cluster Federation project, please read through the Development Guide:
+If you are interested in contributing to Kubernetes Cluster Federation, please read through the Development Guide:
 https://github.com/kubernetes-sigs/kubefed/blob/master/docs/development.md
 
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/kubernetes-sigs/kubefed)](https://goreportcard.com/report/github.com/kubernetes-sigs/kubefed)
 [![Image Repository on Quay](https://quay.io/repository/kubernetes-multicluster/kubefed/status "Image Repository on Quay")](https://quay.io/repository/kubernetes-multicluster/kubefed)
 [![LICENSE](https://img.shields.io/badge/license-apache2.0-green.svg)](https://github.com/kubernetes-sigs/kubefed/blob/master/LICENSE)
-[![Releases](https://img.shields.io/badge/version-v0.0.10-orange.svg)](https://github.com/kubernetes-sigs/kubefed/releases "Kubefed latest release")
+[![Releases](https://img.shields.io/badge/version-v0.0.10-orange.svg)](https://github.com/kubernetes-sigs/kubefed/releases "KubeFed latest release")
 
 # Kubernetes Cluster Federation
 
 This repo contains an in-progress prototype of some of the
-foundational aspects of V2 of Kubernetes Federation.  The prototype
+foundational aspects of Kubernetes Cluster Federation. The prototype
 builds on the sync controller (a.k.a. push reconciler) from
 [Federation v1](https://github.com/kubernetes/federation/) to iterate
 on the API concepts laid down in the [brainstorming
@@ -22,10 +22,10 @@ group](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster).
 
 <p align="center"><img src="docs/images/concepts.png" width="711"></p>
 
-Kubefed is configured with two types of information:
+KubeFed is configured with two types of information:
 
-- **Type configuration** declares which API types Kubefed should handle
-- **Cluster configuration** declares which clusters Kubefed should target
+- **Type configuration** declares which API types KubeFed should handle
+- **Cluster configuration** declares which clusters KubeFed should target
 
 **Propagation** refers to the mechanism that distributes resources to federated
 clusters.
@@ -45,7 +45,7 @@ dynamic scheduling.
 These fundamental concepts provide building blocks that can be used by
 higher-level APIs:
 
-- **Status** collects the status of resources distributed by Kubefed across all federated clusters
+- **Status** collects the status of resources distributed by KubeFed across all federated clusters
 - **Policy** determines which subset of clusters a resource is allowed to be distributed to
 - **Scheduling** refers to a decision-making capability that can decide how 
   workloads should be spread across different clusters similar to how a human
@@ -57,7 +57,7 @@ higher-level APIs:
 |---------|----------|--------------|---------|
 | [Push propagation of arbitrary types to remote clusters](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#example) | Alpha | PushReconciler | true |
 | [CLI utility (`kubefedctl`)](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#operations) | Alpha | | |
-| [Generate Federation APIs without writing code](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#enabling-federation-of-an-api-type) | Alpha | | |
+| [Generate KubeFed APIs without writing code](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#enabling-federation-of-an-api-type) | Alpha | | |
 | [Multicluster Service DNS via `external-dns`](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/servicedns-with-externaldns.md) | Alpha | CrossClusterServiceDiscovery | true |
 | [Multicluster Ingress DNS via `external-dns`](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/ingressdns-with-externaldns.md) | Alpha | FederatedIngress | true |
 | [Replica Scheduling Preferences](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md#replicaschedulingpreference) | Alpha | SchedulerPreferences | true |
@@ -67,7 +67,7 @@ higher-level APIs:
 ### User Guide
 
 Take a look at our [user guide](docs/userguide.md) if you are interested in
-using Kubefed.
+using KubeFed.
 
 ### Development Guide
 

--- a/charts/kubefed/README.md
+++ b/charts/kubefed/README.md
@@ -31,7 +31,7 @@ group](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster).
 
 If your Kubernetes cluster has RBAC enabled, it will be necessary to
 ensure that helm is deployed with a service account with the
-permissions necessary to deploy federation:
+permissions necessary to deploy KubeFed:
 
 ```bash
 $ cat << EOF | kubectl apply -f -
@@ -60,7 +60,7 @@ $ helm init --service-account tiller
 
 ## Installing the Chart
 
-First, add the kubefed chart repo to your local repository.
+First, add the KubeFed chart repo to your local repository.
 ```bash
 $ helm repo add kubefed-charts https://raw.githubusercontent.com/kubernetes-sigs/kubefed/master/charts
 
@@ -84,15 +84,15 @@ $ helm install kubefed-charts/federation-v2 --name kubefed --version=<x.x.x> --n
 
 Due to this helm [issue](https://github.com/helm/helm/issues/4440), the CRDs cannot be deleted
 when delete helm release, so before delete the helm release, we need first delete all
-of the CR and CRDs for kubefed release.
+of the CR and CRDs for KubeFed release.
 
-Delete all kubefed `FederatedTypeConfig`:
+Delete all KubeFed `FederatedTypeConfig`:
 
 ```bash
 $ kubectl -n kube-federation-system delete FederatedTypeConfig --all
 ```
 
-Delete all kubefed CRDs:
+Delete all KubeFed CRDs:
 
 ```bash
 $ kubectl delete crd $(kubectl get crd | grep -E 'kubefed.k8s.io' | awk '{print $1}')
@@ -109,16 +109,16 @@ and deletes the release.
 
 ## Configuration
 
-The following tables lists the configurable parameters of the Kubefed
+The following tables lists the configurable parameters of the KubeFed
 chart and their default values.
 
 | Parameter                             | Description                                                                                                                                                                                 | Default                         |
 | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------|
-| controllermanager.enabled             | Specifies whether to enable the controller manager in kubefed.                                                                                                                              | true                            |
-| controllermanager.replicaCount        | Number of replicas for kubefed controller manager.                                                                                                                                          | 2                               |
-| controllermanager.repository          | Repo of the kubefed image.                                                                                                                                                                  | quay.io/kubernetes-multicluster |
-| controllermanager.image               | Name of the kubefed image.                                                                                                                                                                  | kubefed                         |
-| controllermanager.tag                 | Tag of the kubefed image.                                                                                                                                                                   | latest                          |
+| controllermanager.enabled             | Specifies whether to enable the controller manager in KubeFed.                                                                                                                              | true                            |
+| controllermanager.replicaCount        | Number of replicas for KubeFed controller manager.                                                                                                                                          | 2                               |
+| controllermanager.repository          | Repo of the KubeFed image.                                                                                                                                                                  | quay.io/kubernetes-multicluster |
+| controllermanager.image               | Name of the KubeFed image.                                                                                                                                                                  | kubefed                         |
+| controllermanager.tag                 | Tag of the KubeFed image.                                                                                                                                                                   | latest                          |
 | controllermanager.imagePullPolicy     | Image pull policy.                                                                                                                                                                          | IfNotPresent                    |
 | controllermanager.featureGates.PushReconciler               | Push reconciler feature.                                                                                                                                              | true                            |
 | controllermanager.featureGates.SchedulerPreferences         | Scheduler preferences feature.                                                                                                                                        | true                            |
@@ -135,7 +135,7 @@ chart and their default values.
 | controllermanager.clusterHealthCheckSuccessThreshold | Minimum consecutive successes for the cluster health to be considered successful after having failed.                                                                        | 1                               |
 | controllermanager.clusterHealthCheckTimeoutSeconds   | Number of seconds after which the cluster health check times out.                                                                                                            | 3                               |
 | controllermanager.syncController.adoptResources  | Whether to adopt pre-existing resource in member clusters.                                                                                                        		          | Enabled                         |
-| global.scope                   | Whether the kubefed namespace will be the only target for federation.                                                                                                                           | Cluster                         |
+| global.scope                   | Whether the KubeFed namespace will be the only target for federation.                                                                                                                           | Cluster                         |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -2,19 +2,19 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Kubefed Concepts](#kubefed-concepts)
+- [KubeFed Concepts](#kubefed-concepts)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-### Kubefed Concepts
+### KubeFed Concepts
 
 | Concept              | Description                                                                                                                                                                                                                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Federate             | Federating a set of Kubernetes clusters means, effectively creating a common interface to the pool of these clusters which can be used to deploy Kubernetes applications across those clusters.                                                                                                                     |
-| Federation           | Kubernetes Cluster Federation enables users to federate multiple Kubernetes clusters for resources distribution, service discovery, high availability etc across multiple clusters.                                                                                                                                 |
-| Host Cluster         | A cluster which is used to expose the federation API and run the kubefed control plane.                                                                                                                                                                                                                          |
+| KubeFed           | Kubernetes Cluster Federation enables users to federate multiple Kubernetes clusters for resources distribution, service discovery, high availability etc across multiple clusters.                                                                                                                                 |
+| Host Cluster         | A cluster which is used to expose the KubeFed API and run the KubeFed control plane.                                                                                                                                                                                                                          |
 | Cluster Registration | A cluster join the Host Cluster via command `kubefedctl join`.                                                                                                                                                                                                                                                        |
-| Member Cluster       | A cluster which is registered with the federation API and that kubefed controllers have authentication credentials for. The Host Cluster can also be a Member Cluster.                                                                                                                                           |
+| Member Cluster       | A cluster which is registered with the KubeFed API and that KubeFed controllers have authentication credentials for. The Host Cluster can also be a Member Cluster.                                                                                                                                           |
 | ServiceDNSRecord     | A resource that associates one or more Kubernetes Service resources and how to access the Service, with a scheme for constructing Domain Name System (DNS) [resource records](https://www.ietf.org/rfc/rfc1035.txt) for the Service.                                                                                |
 | IngressDNSRecord     | A resource that associates one or more [Kubernetes Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) and how to access the Kubernetes Ingress resources, with a scheme for constructing Domain Name System (DNS) [resource records](https://www.ietf.org/rfc/rfc1035.txt) for the Ingress. |
 | DNSEndpoint          | A [Custom Resource](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) wrapper for the Endpoint resource.                                                                                                                                                                       |

--- a/docs/development.md
+++ b/docs/development.md
@@ -10,7 +10,7 @@
     - [docker](#docker)
   - [Adding a new API type](#adding-a-new-api-type)
   - [Running E2E Tests](#running-e2e-tests)
-    - [Setup Clusters and Deploy the Kubefed Control Plane](#setup-clusters-and-deploy-the-kubefed-control-plane)
+    - [Setup Clusters and Deploy the KubeFed Control Plane](#setup-clusters-and-deploy-the-kubefed-control-plane)
     - [Running Tests](#running-tests)
     - [Running Tests With In-Memory Controllers](#running-tests-with-in-memory-controllers)
     - [Cleanup](#cleanup)
@@ -24,14 +24,14 @@
 
 # Development Guide
 
-If you would like to contribute to the kubefed project, this guide will
+If you would like to contribute to the KubeFed project, this guide will
 help you get started.
 
 ## Prerequisites
 
 ### Binaries
 
-The Kubefed deployment depends on `kubebuilder`, `etcd`, `kubectl`, and
+The KubeFed deployment depends on `kubebuilder`, `etcd`, `kubectl`, and
 `kube-apiserver` >= v1.13 being installed in the path. The `kubebuilder`
 ([v1.0.8](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v1.0.8)
 as of this writing) release packages all of these dependencies together.
@@ -46,7 +46,7 @@ export PATH=$(pwd)/bin:${PATH}
 
 ### kubernetes
 
-The kubefed deployment requires kubernetes version >= 1.13. To see a detailed list of binaries required, see the prerequisites section in the [user guide](./userguide.md#prerequisites)
+The KubeFed deployment requires kubernetes version >= 1.13. To see a detailed list of binaries required, see the prerequisites section in the [user guide](./userguide.md#prerequisites)
 
 ## Prerequisites
 
@@ -60,7 +60,7 @@ Set up your [Docker environment](https://docs.docker.com/install/).
 
 As per the
 [docs](http://book.kubebuilder.io/quick_start.html)
-for kubebuilder, bootstrapping a new kubefed API type can be
+for kubebuilder, bootstrapping a new KubeFed API type can be
 accomplished as follows:
 
 ```bash
@@ -85,8 +85,8 @@ non-generated code in the commit history.
 
 ## Running E2E Tests
 
-The kubefed E2E tests must be executed against a deployed
-federation of one or more clusters.  Optionally, the federation
+The KubeFed E2E tests must be executed against a deployed
+federation of one or more clusters.  Optionally, the KubeFed
 controllers can be run in-memory to enable debugging.
 
 Many of the tests validate CRUD operations for each of the federated
@@ -100,15 +100,15 @@ types enabled by default:
 
 The read operation is implicit.
 
-### Setup Clusters and Deploy the Kubefed Control Plane
+### Setup Clusters and Deploy the KubeFed Control Plane
 
 In order to run E2E tests, you first need to:
 
 1. Create clusters
    - See the [user guide for a way to deploy clusters](userguide.md#create-clusters)
-     for testing kubefed.
-1. Deploy the kubefed control plane
-   - To deploy the latest version of the kubefed control plane, follow
+     for testing KubeFed.
+1. Deploy the KubeFed control plane
+   - To deploy the latest version of the KubeFed control plane, follow
      the [Helm chart deployment in the user guide](../charts/kubefed/README.md#installing-the-chart).
    - To deploy your own changes, follow the [Test Your Changes](#test-your-changes)
      section of this guide.
@@ -146,13 +146,13 @@ dlv test -- -kubeconfig=/path/to/kubeconfig -test.v \
 
 ### Running Tests With In-Memory Controllers
 
-Running the kubefed controllers in-memory for a test run allows the
+Running the KubeFed controllers in-memory for a test run allows the
 controllers to be targeted by a debugger (e.g. delve) or the golang
 race detector.  The prerequisite for this mode is scaling down the
-kubefed controller manager:
+KubeFed controller manager:
 
 1. Reduce the `kubefed-controller-manager` deployment replicas to 0. This way
-   we can launch the necessary kubefed controllers ourselves via the test
+   we can launch the necessary KubeFed controllers ourselves via the test
    binary.
 
    ```bash
@@ -193,7 +193,7 @@ Follow the [cleanup instructions in the user guide](../charts/kubefed/README.md#
 In order to test your changes on your kubernetes cluster, you'll need
 to build an image and a deployment config.
 
-**NOTE:** When federation CRDs are changed, you need to run:
+**NOTE:** When KubeFed CRDs are changed, you need to run:
 ```bash
 make generate
 ```

--- a/docs/environments/gke.md
+++ b/docs/environments/gke.md
@@ -9,7 +9,7 @@
 
 # Google Kubernetes Engine (GKE) Deployment Guide
 
-Kubefed can be deployed to and manage [GKE](https://cloud.google.com/kubernetes-engine/) clusters running
+KubeFed can be deployed to and manage [GKE](https://cloud.google.com/kubernetes-engine/) clusters running
 Kubernetes v1.13 or greater. The following example deploys two GKE clusters named `cluster1` and `cluster2`.
 
 ```bash
@@ -19,7 +19,7 @@ gcloud container clusters create cluster1 --zone $ZONE --cluster-version $GKE_VE
 gcloud container clusters create cluster2 --zone $ZONE --cluster-version $GKE_VERSION
 ```
 
-If you are following along with the Kubefed [User Guide](../userguide.md), change the cluster context names:
+If you are following along with the KubeFed [User Guide](../userguide.md), change the cluster context names:
 
 ```bash
 export GCP_PROJECT=$(gcloud config list --format='value(core.project)')
@@ -27,12 +27,12 @@ kubectl config rename-context gke_${GCP_PROJECT}_${ZONE}_cluster1 cluster1
 kubectl config rename-context gke_${GCP_PROJECT}_${ZONE}_cluster2 cluster2
 ```
 
-Before proceeding with the Kubefed deployment, you must complete the steps in the RBAC Workaround section of this
+Before proceeding with the KubeFed deployment, you must complete the steps in the RBAC Workaround section of this
 document.
 
 ## RBAC Workaround
 
-You can expect the following error when deploying Kubefed to Google Kubernetes Engine (GKE)
+You can expect the following error when deploying KubeFed to Google Kubernetes Engine (GKE)
 v1.6 or later:
 
 ```
@@ -62,4 +62,4 @@ kubectl create clusterrolebinding myname-cluster-admin-binding --clusterrole=clu
 ```
 
 Once all pods are running you can return to the [User Guide](../userguide.md) to deploy the
-Kubefed control-plane.
+KubeFed control-plane.

--- a/docs/environments/icp.md
+++ b/docs/environments/icp.md
@@ -10,8 +10,8 @@
 
 # IBM Cloud Private Deployment Guide
 
-Kubefed can be deployed to and manage [IBM Cloud Private](https://www.ibm.com/cloud/private) clusters.
-As Kubefed requires Kubernetes v1.13 or greater, please make sure to deploy IBM Cloud Private 3.1.1
+KubeFed can be deployed to and manage [IBM Cloud Private](https://www.ibm.com/cloud/private) clusters.
+As KubeFed requires Kubernetes v1.13 or greater, please make sure to deploy IBM Cloud Private 3.1.1
 or higher.
 
 The following example deploys two IBM Cloud Private 3.1.1 clusters named `cluster1` and `cluster2`.
@@ -22,7 +22,7 @@ Please follow the [guide in IBM Cloud Private 3.1.1 Knowledge Center](https://ww
 to install.
 
 **NOTE:** We need to install two clusters named `cluster1` and `cluster2`, so after `cluster/config.yaml`
-is generated, update the names of the 2 clusters to 'cluster1' and 'cluster2' before installing federation.
+is generated, update the names of the 2 clusters to 'cluster1' and 'cluster2' before installing KubeFed.
 
 For the first cluster, set the following value in `cluster/config.yaml` as follows:
 
@@ -39,7 +39,7 @@ cluster_name: cluster2
 ## Post Install Configuration
 
 As IBM Cloud Private is [enforcing container image security](https://www.ibm.com/support/knowledgecenter/SSBS6K_3.1.1/manage_images/image_security.html)
-policy by default, and the default image security policy does not allow pulling the Kubefed
+policy by default, and the default image security policy does not allow pulling the KubeFed
 image from `quay.io/kubernetes-multicluster/kubefed:*`, we need to update the image security
 policy as follows:
 
@@ -56,4 +56,4 @@ spec:
 ```
 
 Once all pods are running you can return to the [User Guide](../userguide.md) to deploy the
-Kubefed control-plane.
+KubeFed control-plane.

--- a/docs/environments/kind.md
+++ b/docs/environments/kind.md
@@ -17,7 +17,7 @@
 # `kind` - `k`ubernetes `in` `d`ocker
 
 [kind](https://github.com/kubernetes-sigs/kind) provides the quickest way to
-set up clusters for use with the Kubefed control plane.
+set up clusters for use with the KubeFed control plane.
 
 ## Download and Install kind
 

--- a/docs/environments/minikube.md
+++ b/docs/environments/minikube.md
@@ -9,7 +9,7 @@
 # Minikube
 
 [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube/)
-provides one of the quickest way to set-up clusters for use with the kubefed.
+provides one of the quickest way to set-up clusters for use with KubeFed.
 
 **NOTE:** You will need to use a minikube version that supports
 deploying a kubernetes cluster >= 1.13. [Recently
@@ -32,4 +32,4 @@ kubectl get all --all-namespaces
 ```
 
 After all pods reach a Running status, you can return to the [User Guide](../userguide.md) to deploy the cluster
-registry and Kubefed control plane.
+registry and KubeFed control plane.

--- a/docs/ingress-service-dns-with-coredns.md
+++ b/docs/ingress-service-dns-with-coredns.md
@@ -2,10 +2,10 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Federation DNS for Ingress and Service](#federation-dns-for-ingress-and-service)
-  - [Creating federation cluster](#creating-federation-cluster)
+- [KubeFed DNS for Ingress and Service](#kubefed-dns-for-ingress-and-service)
+  - [Creating KubeFed cluster](#creating-kubefed-cluster)
   - [Installing ExternalDNS](#installing-externaldns)
-  - [Enable DNS for federation resources](#enable-dns-for-federation-resources)
+  - [Enable DNS for KubeFed resources](#enable-dns-for-kubefed-resources)
     - [Installing MetalLB for LoadBalancer Service](#installing-metallb-for-loadbalancer-service)
     - [Creating service resources](#creating-service-resources)
     - [Enable the ingress controller](#enable-the-ingress-controller)
@@ -14,9 +14,9 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Federation DNS for Ingress and Service
+# KubeFed DNS for Ingress and Service
 
-This tutorial describes how to set up a federation cluster DNS with [ExternalDNS](https://github.com/kubernetes-incubator/external-dns/) based on [CoreDNS](https://github.com/coredns/coredns) in [minikube](https://github.com/kubernetes/minikube) clusters. It provides guidance for the following steps:
+This tutorial describes how to set up a KubeFed cluster DNS with [ExternalDNS](https://github.com/kubernetes-incubator/external-dns/) based on [CoreDNS](https://github.com/coredns/coredns) in [minikube](https://github.com/kubernetes/minikube) clusters. It provides guidance for the following steps:
 
 - Install ExternalDNS with etcd enabled CoreDNS as a provider
 - Install [ingress controller](https://github.com/kubernetes/ingress-nginx) for your minikube clusters to enable Ingress resource
@@ -25,16 +25,16 @@ This tutorial describes how to set up a federation cluster DNS with [ExternalDNS
 You can use either Loadbalancer Service or Ingress resource or both in your environment, this tutorial includes guidance for both Loadbalancer Service and Ingress resource.
 For related conceptions of Muilti-cluster Ingress and Service, you can refer to [ingressdns-with-externaldns.md](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/ingressdns-with-externaldns.md) and [servicedns-with-externaldns.md](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/servicedns-with-externaldns.md).
 
-## Creating federation cluster
+## Creating KubeFed cluster
 
-Install Kubefed with minikube in [User Guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md).
+Install KubeFed with minikube in [User Guide](https://github.com/kubernetes-sigs/kubefed/blob/master/docs/userguide.md).
 
 ## Installing ExternalDNS
 
 Install ExternalDNS with CoreDNS as backend in your host cluster. You can follow the [tutorial](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/coredns.md).  
 **Note**: You should replace `parameters: example.org` with `parameters: example.com` when [Installing CoreDNS](https://github.com/kubernetes-incubator/external-dns/blob/master/docs/tutorials/coredns.md#installing-coredns)
 
-To make it work for federation resources, you need to use below ExternalDNS deployment instead of the one in the tutorial.
+To make it work for KubeFed resources, you need to use below ExternalDNS deployment instead of the one in the tutorial.
 **Note**: You should replace value of `ETCD_URLS` with your own etcd client service IP address.
 
 ```bash
@@ -73,7 +73,7 @@ spec:
 EOF
 ```
 
-## Enable DNS for federation resources
+## Enable DNS for KubeFed resources
 
 ### Installing MetalLB for LoadBalancer Service
 

--- a/docs/ingressdns-with-externaldns.md
+++ b/docs/ingressdns-with-externaldns.md
@@ -22,7 +22,7 @@ external DNS records of Ingress resources in supported DNS providers.
 
 The above diagram illustrates MCIDNS. A typical MCIDNS workflow consists of:
 
-1. Creating `FederatedDeployment`, `FederatedService`, and `FederatedIngress` resources. The Federation sync
+1. Creating `FederatedDeployment`, `FederatedService`, and `FederatedIngress` resources. The KubeFed sync
    controller propagates the corresponding `Deployment`, `Service`, and `Ingress` resources to target clusters.
 2. Creating an `IngressDNSRecord` resource that identifies the intended domain name(s) and optional DNS resource
    record parameters.
@@ -40,7 +40,7 @@ MCIDNS is comprised of multiple types and controllers:
 
 Setting-up MCIDNS can be accomplished by referencing the following documentation:
 
-- The Kubefed [User Guide](userguide.md) to setup one or more Kubernetes clusters and the Federation
+- The KubeFed [User Guide](userguide.md) to setup one or more Kubernetes clusters and the KubeFed
   control-plane. If running in GKE, the cluster hosting the ExternalDNS controller must have scope
   `https://www.googleapis.com/auth/ndev.clouddns.readwrite`.
 - If needed, create a domain name with one of the supported providers or delegate a DNS subdomain for use with
@@ -49,10 +49,10 @@ Setting-up MCIDNS can be accomplished by referencing the following documentation
   controller. You must ensure the following `args` are provided in the external-dns Deployment manifest:
   `--source=crd --crd-source-apiversion=multiclusterdns.kubefed.k8s.io/v1alpha1 --crd-source-kind=DNSEndpoint --registry=txt --txt-prefix=cname`
   **Note**: If you do not deploy the external-dns controller to the same namespace and use the default service account
-  of the kubefed control-plane, you must setup RBAC permissions allowing the controller access to necessary
+  of the KubeFed control-plane, you must setup RBAC permissions allowing the controller access to necessary
   resources.
 
-After the cluster, kubefed control-plane, and external-dns controller are running, use the
+After the cluster, KubeFed control-plane, and external-dns controller are running, use the
 [sample](../example/sample1) federated deployment, service, and ingress to test MCIDNS. Check the status of all the
 resources in each cluster by running:
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -2,13 +2,13 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Releasing Kubefed](#releasing-kubefed)
+- [Releasing KubeFed](#releasing-kubefed)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-### Releasing Kubefed
+### Releasing KubeFed
 
-Creating a kubefed release involves the following steps:
+Creating a KubeFed release involves the following steps:
 
 1. Locally create an annotated tag in the format `v[0-9]+.[0-9]+.[0-9]+`
    - `git tag -a <tag> -m "Creating release tag <tag>"`

--- a/docs/servicedns-with-externaldns.md
+++ b/docs/servicedns-with-externaldns.md
@@ -22,7 +22,7 @@ DNS resource records of Kubernetes Service object for supported DNS providers.
 
 The above diagram illustrates MCSDNS. A typical MCSDNS workflow consists of:
 
-1. Creating `FederatedDeployment` and `FederatedService` objects. The Federation sync
+1. Creating `FederatedDeployment` and `FederatedService` objects. The KubeFed sync
    controller propagates the corresponding objects to target clusters.
 2. Creating a `Domain` object that associates a DNS zone and authoritative name server for the federation.
 3. Creating a `ServiceDNSRecord` object that identifies the intended domain name and other optional resource
@@ -48,7 +48,7 @@ MCSDNS is comprised of multiple types and controllers:
 
 Setting-up MCSDNS can be accomplished by referencing the following documentation:
 
-- The Kubefed [User Guide](userguide.md) to setup one or more Kubernetes clusters and the Federation
+- The KubeFed [User Guide](userguide.md) to setup one or more Kubernetes clusters and the KubeFed
   control-plane. Due to [Issue #370](https://github.com/kubernetes-sigs/kubefed/issues/370), the environment running
   the clusters must support service `type: LoadBalancer`. For the GKE deployment option, the cluster hosting the ExternalDNS controller must have scope
   `https://www.googleapis.com/auth/ndev.clouddns.readwrite`.
@@ -58,10 +58,10 @@ Setting-up MCSDNS can be accomplished by referencing the following documentation
   controller. You must ensure the following `args` are provided in the external-dns Deployment manifest:
   `--source=crd --crd-source-apiversion=multiclusterdns.kubefed.k8s.io/v1alpha1 --crd-source-kind=DNSEndpoint --registry=txt --txt-prefix=cname`
   **Note**: If you do not deploy the external-dns controller to the same namespace and use the default service account
-  of the kubefed control-plane, you must setup RBAC permissions allowing the controller access to necessary
+  of the KubeFed control-plane, you must setup RBAC permissions allowing the controller access to necessary
   resources.
 
-After the cluster, kubefed control-plane, and external-dns controller are running, use the
+After the cluster, KubeFed control-plane, and external-dns controller are running, use the
 [sample](../example/sample1) federated deployment and service to test MCSDNS. You must change the sample service type to
 `LoadBalancer` for the Service DNS controller to populate the status IP of the `ServiceDNSRecord` and the target IP's of
 the `DNSEndpoint`:

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -57,17 +57,17 @@
 
 # User Guide
 
-Please refer to [Kubefed Concepts](./concepts.md) first before you go through this user guide.
+Please refer to [KubeFed Concepts](./concepts.md) first before you go through this user guide.
 
 This user guide contains concepts and procedures to help you get started with Kubefed.
 
-For information about installing Kubefed, see the [installation documentation](./installation.md).
+For information about installing KubeFed, see the [installation documentation](./installation.md).
 
 ## Joining and unjoining clusters
 
 ### Joining clusters
 
-`kubefedctl` is the Kubefed command line utility. You can download
+`kubefedctl` is the KubeFed command line utility. You can download
 the latest binary from the [release page](https://github.com/kubernetes-sigs/kubefed/releases).
 ```bash
 VERSION=<latest-version>
@@ -82,15 +82,15 @@ sudo mv kubefedctl /usr/local/bin/ # make sure the location is in the PATH
 ### Deployment Image
 
 If you follow this user guide without any changes you will be using the latest
-stable released version of the kubefed image tagged as `latest`.
+stable released version of the KubeFed image tagged as `latest`.
 Alternatively, we support the ability to deploy the [latest master image tagged
 as `canary`](development.md#test-latest-master-changes-canary) or [your own
 custom image](development.md#test-your-changes).
 
 ### Create Clusters
 
-The kubefed control plane can run on any v1.13 or greater Kubernetes clusters. The following is a list of
-Kubernetes environments that have been tested and are supported by the Kubefed community:
+The KubeFed control plane can run on any v1.13 or greater Kubernetes clusters. The following is a list of
+Kubernetes environments that have been tested and are supported by the KubeFed community:
 
 - [kind](./environments/kind.md)
 
@@ -100,7 +100,7 @@ Kubernetes environments that have been tested and are supported by the Kubefed c
 
 - [IBM Cloud Private](./environments/icp.md)
 
-After completing the steps in one of the above guides, return here to continue the Kubefed deployment.
+After completing the steps in one of the above guides, return here to continue the KubeFed deployment.
 
 **NOTE:** You must set the correct context using the command below as this guide depends on it.
 
@@ -111,13 +111,13 @@ kubectl config use-context cluster1
 ## Helm Chart Deployment
 
 You can refer to [helm chart installation guide](https://github.com/kubernetes-sigs/kubefed/blob/master/charts/kubefed/README.md)
-to install and uninstall a kubefed control plane.
+to install and uninstall a KubeFed control plane.
 
 ## Operations
 
 ### Join Clusters
 
-You can use the `kubefed2` tool to join clusters as follows.
+You can use the `kubefedctl` tool to join clusters as follows.
 
 ```bash
 kubefedctl join cluster1 --cluster-context cluster1 \
@@ -145,7 +145,7 @@ cluster2   True    1m
 ```
 ### Unjoining clusters
 
-You can unjoin clusters using `kubefed2` tool as follows.
+You can unjoin clusters using `kubefedctl` tool as follows.
 
 ```bash
 kubefedctl unjoin cluster2 --cluster-context cluster2 --host-cluster-context cluster1 --v=2
@@ -248,7 +248,7 @@ and **deployments**.apps) match, the crd name of the generated federated type wo
 
 `kubefedctl enable --federation-group string` specifies the name of the API group to use for the
 generated federation type. It is `types.kubefed.k8s.io` by default. If a new federation group is
-enabled, the RBAC permissions for the kubefed controller manager will need to be updated to include
+enabled, the RBAC permissions for the KubeFed controller manager will need to be updated to include
 permissions for the new group.
 
 For example, after federation deployment, `deployments.apps` is enabled by default. To enable
@@ -272,7 +272,7 @@ kubectl patch clusterrole kubefed-role --type='json' -p='[{"op": "add", "path": 
 }]'
 ```
 This example is for cluster scoped federation deployment. For namespaced federation deployment,
-you can patch role `kubefed-role` in the kubefed namespace instead.
+you can patch role `kubefed-role` in the KubeFed namespace instead.
 
 ### Disabling federation of an API type
 
@@ -572,7 +572,7 @@ done
 ```
 
 If you were able to verify the resources removed and added back then you have
-successfully verified a working kubefed deployment.
+successfully verified a working KubeFed deployment.
 
 #### Cleaning up
 
@@ -590,10 +590,10 @@ to via the `spec.placement.clusters` field of a federated resource, it is possib
 use the `spec.placement.clusterSelector` field to provide a label selector that determines
 a list of clusters at runtime.
 
-If the goal is to select a subset of member clusters, make sure that the `KubefedCluster` binaries from pre-reqs [now covered by Helm installation]
+If the goal is to select a subset of member clusters, make sure that the `KubeFedCluster` binaries from pre-reqs [now covered by Helm installation]
 resources that are intended to be selected have the appropriate labels applied.
 
-The following command is an example to label a `KubefedCluster`:
+The following command is an example to label a `KubeFedCluster`:
 
 ```bash
 kubectl label kubefedclusters -n kube-federation-system cluster1 foo=bar
@@ -673,7 +673,7 @@ An example for CRD of `federatedserviceaccounts` is as follows:
 kubectl describe federatedserviceaccounts test-serviceaccount -n test-namespace
 ```
 
-It may also be useful to inspect the kubefed controller log as follows:
+It may also be useful to inspect the KubeFed controller log as follows:
 
 ```bash
 kubectl logs deployment/kubefed-controller-manager -n kube-federation-system
@@ -702,11 +702,11 @@ On successful completion of the script, both `cluster1` and
 ## Namespaced Federation
 
 All prior instructions referred to the deployment and use of a
-cluster-scoped kubefed control plane. It is also possible to
+cluster-scoped KubeFed control plane. It is also possible to
 deploy a namespace-scoped control plane. In this mode of operation,
-kubefed controllers will target resources in a single namespace on
+KubeFed controllers will target resources in a single namespace on
 both host and member clusters. This may be desirable when
-experimenting with kubefed on a production cluster.
+experimenting with KubeFed on a production cluster.
 
 ### Helm Configuration
 
@@ -733,7 +733,7 @@ kubefedctl join mycluster --cluster-context mycluster \
 
 ## Local Value Retention
 
-In most cases, the kubefed sync controller will overwrite any
+In most cases, the KubeFed sync controller will overwrite any
 changes made to resources it manages in member clusters.  The
 exceptions appear in the following table.  Where retention is
 conditional, an explanation will be provided in a subsequent section.
@@ -763,7 +763,7 @@ federated resource for each retention strategy (i.e. one with
 ### ServiceAccount
 
 A populated `secrets` field of a `ServiceAccount` resource managed by
-kubefed will be retained if the managing federated resource does
+KubeFed will be retained if the managing federated resource does
 not specify a value for the field.  This avoids the possibility of the
 sync controller attempting to repeatedly clear the field while a local
 serviceaccounts controller attempts to repeatedly set it to a
@@ -771,10 +771,10 @@ generated value.
 
 ## Higher order behaviour
 
-The architecture of kubefed API allows higher level APIs to be constructed using the
+The architecture of KubeFed API allows higher level APIs to be constructed using the
 mechanics provided by the standard form of the federated API types (containing fields for
 `template`, `placement` and `override`) and associated controllers for a given resource.
-Further sections describe few of higher level APIs implemented as part of Kubefed.
+Further sections describe few of higher level APIs implemented as part of KubeFed.
 
 ### Multi-Cluster Ingress DNS
 
@@ -960,7 +960,7 @@ Replica layout: C=20
 
 ## Controller-Manager Leader Election
 
-The kubefed controller manager is always deployed with leader election feature
+The KubeFed controller manager is always deployed with leader election feature
 to ensure high availability of the control plane. Leader election module ensures
 there is always a leader elected among multiple instances which takes care of
 running the controllers. In case the active instance goes down, one of the standby instances


### PR DESCRIPTION
The Federation project has been renamed KubeFed. This change renames all
appropriate occurrences in the docs.

The format is KubeFed, in UpperCamel, per agreement on 2019-05-15
Federation WG meeting. The longform is Kubernetes Cluster Federation,
per clarification on PR #912. The kubefed2 CLI tool was renamed
kubefedctl, per the 0.0.10 changelog.

Specifically searched for:
* Kubefed (case sensitive)
  * Should not occur except in immutable CHANGELOG.
* kubefed (case sensitive)
  * Should only occur when in code, URLs, Markdown links, similar.
* kubefed (case insensitive)
  * Reviewed for any unexpected capitalizations, found none.
* v2 (case insensitive)
  * Should not occur in relation to Federation
* Federation (case sensitive)
  * Should only occur in immutable CHANGELOG, in reference to history of
    Federation v1, or at the start of a sentence or in heading when
    referring to the concept of federation, not the project name
    "Federation".
* kubefed2
  * Should only occur in immutable CHANGELOG.

Announcement of name change:

https://groups.google.com/d/msg/kubernetes-sig-multicluster
/HHyqrfFHQiw/HJ3F6dOHBAAJ

Signed-off-by: Daniel Farrell <dfarrell@redhat.com>