### PR TITLE
Fix broken chart index link for v0.1.0-rc1

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -32,6 +32,6 @@ entries:
     digest: 4f829657ea2088c176869d8e65435926b59f5cf1f7f1ce0102fae3a81c576d5e
     name: kubefed
     urls:
-    - https://sigs.k8s.io/kubefed/releases/download/v0.1.0-rc1/kubefed-0.1.0-rc1.tgz
+    - https://github.com/kubernetes-sigs/kubefed/releases/download/v0.1.0-rc1/kubefed-0.1.0-rc1.tgz
     version: 0.1.0-rc1
 generated: 2019-05-22T15:59:04.158053632-07:00

--- a/charts/kubefed/README.md
+++ b/charts/kubefed/README.md
@@ -77,7 +77,7 @@ $ helm search kubefed
 Install the chart and specify the version to install with the
 `--version` argument. Replace `<x.x.x>` with your desired version.
 ```bash
-$ helm install kubefed-charts/federation-v2 --name kubefed --version=<x.x.x> --namespace kube-federation-system
+$ helm install kubefed-charts/kubefed --name kubefed --version=<x.x.x> --namespace kube-federation-system
 ```
 
 ## Uninstalling the Chart
@@ -144,5 +144,5 @@ Alternatively, a YAML file that specifies the values for the parameters can be
 provided while installing the chart. For example:
 
 ```bash
-$ helm install kubefed-charts/federation-v2 --name kubefed --namespace kube-federation-system --values values.yaml
+$ helm install kubefed-charts/kubefed --name kubefed --namespace kube-federation-system --values values.yaml
 ```

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -58,7 +58,7 @@ pushd "${ROOT_DIR}"
     helm package kubefed
 
     # Update the repo index (will need to be committed)
-    helm repo index . --merge index.yaml --url="https://sigs.k8s.io/kubefed/releases/download/${RELEASE_TAG}"
+    helm repo index . --merge index.yaml --url="https://github.com/kubernetes-sigs/kubefed/releases/download/${RELEASE_TAG}"
 
     sha256sum "kubefed-${RELEASE_VERSION}.tgz" > "kubefed-${RELEASE_VERSION}.tgz.sha"
     mv kubefed-${RELEASE_VERSION}.tgz* "${ROOT_DIR}/"


### PR DESCRIPTION
The vanity url doesn't work for asset download links.

This commit also fixes the use of the vanity url in the asset build script and updates the chart readme to refer to the `kubefed` chart.