### PR TITLE
Remove all trace of comparisonfield

### DIFF
--- a/pkg/apis/core/common/constants.go
+++ b/pkg/apis/core/common/constants.go
@@ -26,15 +26,6 @@ const (
 	ClusterOffline ClusterConditionType = "Offline"
 )
 
-type VersionComparisonField string
-
-const (
-	// ResourceVersionComparison indicates comparison via the ResourceVersion field
-	ResourceVersionField VersionComparisonField = "ResourceVersion"
-	// GenerationComparison indicates comparison via the Generation field
-	GenerationField = "Generation"
-)
-
 const (
 	NamespaceName = "namespaces"
 )

--- a/pkg/apis/core/v1alpha1/clusterpropagatedversion_types.go
+++ b/pkg/apis/core/v1alpha1/clusterpropagatedversion_types.go
@@ -29,14 +29,14 @@ type ClusterPropagatedVersionSpec struct {
 // +genclient:nonNamespaced
 
 // ClusterPropagatedVersion holds version information about the state
-// propagated from cluster-scoped federation APIs configured by
-// FederatedTypeConfig to target clusters. The name of a
-// ClusterPropagatedVersion encodes the kind and name of the resource
-// it stores information for. The type of version information stored
-// in ClusterPropagatedVersion will be the metadata.resourceVersion or
-// metadata.Generation of the resource depending on the value of
-// spec.comparisonField in the FederatedTypeConfig associated with the
-// resource.
+// propagated from KubeFed APIs (configured by FederatedTypeConfig
+// resources) to member clusters. The name of a ClusterPropagatedVersion
+// encodes the kind and name of the resource it stores information for
+// (i.e. <lower-case kind>-<resource name>). If a target resource has
+// a populated metadata.Generation field, the generation will be
+// stored with a prefix of `gen:` as the version for the cluster.  If
+// metadata.Generation is not available, metadata.ResourceVersion will
+// be stored with a prefix of `rv:` as the version for the cluster.
 //
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=clusterpropagatedversions

--- a/pkg/apis/core/v1alpha1/propagatedversion_types.go
+++ b/pkg/apis/core/v1alpha1/propagatedversion_types.go
@@ -46,13 +46,15 @@ type ClusterObjectVersion struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// PropagatedVersion holds version information about the state propagated from
-// federation APIs configured by FederatedTypeConfig to target clusters. The
-// name of a PropagatedVersion encodes the kind and name of the resource it
-// stores information for. The type of version information stored in
-// PropagatedVersion will be the metadata.resourceVersion or metadata.Generation
-// of the resource depending on the value of spec.comparisonField in the
-// FederatedTypeConfig associated with the resource.
+// PropagatedVersion holds version information about the state
+// propagated from KubeFed APIs (configured by FederatedTypeConfig
+// resources) to member clusters. The name of a PropagatedVersion
+// encodes the kind and name of the resource it stores information for
+// (i.e. <lower-case kind>-<resource name>). If a target resource has
+// a populated metadata.Generation field, the generation will be
+// stored with a prefix of `gen:` as the version for the cluster.  If
+// metadata.Generation is not available, metadata.ResourceVersion will
+// be stored with a prefix of `rv:` as the version for the cluster.
 //
 // +k8s:openapi-gen=true
 // +kubebuilder:resource:path=propagatedversions

--- a/pkg/kubefedctl/enable/directive.go
+++ b/pkg/kubefedctl/enable/directive.go
@@ -19,7 +19,6 @@ package enable
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 	"sigs.k8s.io/kubefed/pkg/kubefedctl/options"
 )
 
@@ -28,10 +27,6 @@ type EnableTypeDirectiveSpec struct {
 	// The API version of the target type.
 	// +optional
 	TargetVersion string `json:"targetVersion,omitempty"`
-
-	// Which field of the target type determines whether kubefed
-	// considers two resources to be equal.
-	ComparisonField common.VersionComparisonField `json:"comparisonField"`
 
 	// The name of the API group to use for generated federated types.
 	// +optional

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/rest"
 
-	apicommon "sigs.k8s.io/kubefed/pkg/apis/core/common"
 	fedv1b1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 	"sigs.k8s.io/kubefed/pkg/kubefedctl"
@@ -140,7 +139,6 @@ func validateCrdCrud(f framework.FederationFramework, targetCrdKind string, name
 			TargetVersion:    targetAPIResource.Version,
 			FederatedGroup:   targetAPIResource.Group,
 			FederatedVersion: targetAPIResource.Version,
-			ComparisonField:  apicommon.ResourceVersionField,
 		},
 	}
 


### PR DESCRIPTION
`comparisonField` is a legacy field that was removed in favor of dynamically determining which metadata field to use in propagation
versioning.  This commit removes all remaining traces of the field.