### PR TITLE
Report NamespaceNotFederated in propagation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+-  [#951](https://github.com/kubernetes-sigs/kubefed/issues/951)
+   Propagation status for a namespaced federated resource whose
+   containing namespace is not federated now indicates an unhealthy
+   state.
 -  [#1053](https://github.com/kubernetes-sigs/kubefed/pull/1053) API group
    changed from kubefed.k8s.io to kubefed.io.
 
@@ -16,13 +20,13 @@
    for defaulting KubeFedConfigs using mutating admission webhook.
 -  [#1038](https://github.com/kubernetes-sigs/kubefed/pull/1038) Removed template validation schema from Federated API's to facilitate upgrade scenarios.
 -  [#690](https://github.com/kubernetes-sigs/kubefed/issues/690) Extends `kubefedctl`
-   by adding the `orphaning-deletion` command, which allows to `enable` or `disable`  
-   leaving managed resources, when their relevant federated resource is deleted. 
-   In addition, the command allows to check current `status` of the orphaning deletion 
+   by adding the `orphaning-deletion` command, which allows to `enable` or `disable`
+   leaving managed resources, when their relevant federated resource is deleted.
+   In addition, the command allows to check current `status` of the orphaning deletion
    mode.
--  [#1044](https://github.com/kubernetes-sigs/kubefed/issues/1044) If a target namespace  
+-  [#1044](https://github.com/kubernetes-sigs/kubefed/issues/1044) If a target namespace
    of `federate` and all `orphaning-deletion` commands is not specified, use the namespace from
-   the client kubeconfig context. 
+   the client kubeconfig context.
 
 # v0.1.0-rc3
 -  [#520](https://github.com/kubernetes-sigs/kubefed/issues/520) Adds support

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -398,6 +398,7 @@ one of the following values:
 | CheckClusters          | One or more clusters is not in the desired state. |
 | ClusterRetrievalFailed | An error prevented retrieval of member clusters. |
 | ComputePlacementFailed | An error prevented computation of placement. |
+| NamespaceNotFederated  | The containing namespace is not federated. |
 
 For reasons other than `CheckClusters`, an event will be logged with
 the same reason and can be examined for more detail:
@@ -407,6 +408,9 @@ kubectl describe federatednamespace myns -n myns | grep ComputePlacementFailed
 
 Warning  ComputePlacementFailed  5m   federatednamespace-controller  Invalid selector <nil>
 ```
+
+If the reason is `NamespaceNotFederated`, the containing namespace can be
+federated by invoking `kubefedctl federate namespace <namespace name>`.
 
 #### Troubleshooting CheckClusters
 

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -49,6 +49,7 @@ type FederatedResource interface {
 	UpdateVersions(selectedClusters []string, versionMap map[string]string) error
 	DeleteVersions()
 	ComputePlacement(clusters []*fedv1b1.KubeFedCluster) (selectedClusters sets.String, err error)
+	NamespaceNotFederated() bool
 }
 
 type federatedResource struct {
@@ -126,6 +127,10 @@ func (r *federatedResource) ComputePlacement(clusters []*fedv1b1.KubeFedCluster)
 		return computeNamespacedPlacement(r.federatedResource, r.fedNamespace, clusters, r.limitedScope)
 	}
 	return computePlacement(r.federatedResource, clusters)
+}
+
+func (r *federatedResource) NamespaceNotFederated() bool {
+	return r.typeConfig.GetNamespaced() && r.fedNamespace == nil
 }
 
 func (r *federatedResource) IsNamespaceInHostCluster(clusterObj pkgruntime.Object) bool {

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -66,6 +66,7 @@ const (
 	ClusterRetrievalFailed AggregateReason = "ClusterRetrievalFailed"
 	ComputePlacementFailed AggregateReason = "ComputePlacementFailed"
 	CheckClusters          AggregateReason = "CheckClusters"
+	NamespaceNotFederated  AggregateReason = "NamespaceNotFederated"
 
 	PropagationConditionType ConditionType = "Propagation"
 )

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -30,7 +30,10 @@ CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
 COMMON_TEST_CMD="go test -v"
 COMMON_TEST_ARGS="./test/e2e -args  -kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs"
 E2E_TEST_CMD="${COMMON_TEST_CMD} ${COMMON_TEST_ARGS}"
-IN_MEMORY_E2E_TEST_CMD="${COMMON_TEST_CMD} -race ${COMMON_TEST_ARGS} -in-memory-controllers=true"
+# Disable limited scope in-memory controllers to ensure the controllers in the
+# race detection test behave consistently with deployed controllers for a
+# given control plane scope.
+IN_MEMORY_E2E_TEST_CMD="${COMMON_TEST_CMD} -race ${COMMON_TEST_ARGS} -in-memory-controllers=true -limited-scope-in-memory-controllers=false"
 
 function build-binaries() {
   ${MAKE_CMD} hyperfed

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -42,6 +42,15 @@ func (t *TestContextType) RunControllers() bool {
 	return t.InMemoryControllers
 }
 
+// NamespaceScopedControlPlane indicates that the control plane is
+// effectively namespace-scoped. This may be either because in-memory
+// controllers are running namespace-scoped against a cluster-scoped
+// deployment (a debugging optimization) or if a deployed control
+// plane is running namespace-scoped.
+func (t *TestContextType) NamespaceScopedControlPlane() bool {
+	return t.InMemoryControllers && t.LimitedScopeInMemoryControllers || t.LimitedScope
+}
+
 var TestContext *TestContextType = &TestContextType{}
 
 func registerFlags(t *TestContextType) {


### PR DESCRIPTION
Previously a namespaced resource whose containing namespace was not federated (i.e. did not contain a `FederatedNamespace` resource) would report a healthy propagation status.  This has been changed to reporting unhealthy propagation status with reason `NamespaceNotFederated`.

Fixes #951 