### PR TITLE
Fix macos deployment compatibility

### DIFF
--- a/docs/environments/kind.md
+++ b/docs/environments/kind.md
@@ -76,14 +76,14 @@ enabling TLS. **This only needs to be done once for a particular host**.
 See the [docker docs](https://docs.docker.com/registry) for more details.
 
 In order to configure an insecure container registry, you can pass the
-`CONFIGURE_INSECURE_REGISTRY` flag to `create-clusters.sh` as shown below. The
+`CONFIGURE_INSECURE_REGISTRY_HOST` flag to `create-clusters.sh` as shown below. The
 default container registry host is `172.17.0.1:5000` and needs to match
 the IP address of the default docker bridge on your host, typically
 `172.17.0.1`. If you would like to change this then set the
 `CONTAINER_REGISTRY_HOST="<host>:<port>"` flag.
 
 ```bash
-CONFIGURE_INSECURE_REGISTRY=y ./scripts/create-clusters.sh
+CONFIGURE_INSECURE_REGISTRY_HOST=y ./scripts/create-clusters.sh
 ```
 
 This will automatically create the necessary dockerd daemon config and reload

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -9,6 +9,7 @@
   - [Helm Chart Deployment](#helm-chart-deployment)
   - [Operations](#operations)
     - [Join Clusters](#join-clusters)
+      - [Joining kind clusters on MacOS](#joining-kind-clusters-on-macos)
     - [Checking status of joined clusters](#checking-status-of-joined-clusters)
     - [Unjoining clusters](#unjoining-clusters)
   - [Federated API types](#federated-api-types)
@@ -114,12 +115,6 @@ kubectl config use-context cluster1
 You can refer to [helm chart installation guide](https://github.com/kubernetes-sigs/kubefed/blob/master/charts/kubefed/README.md)
 to install and uninstall a KubeFed control plane.
 
-### Fix Cluster Registry meta (Optional)
-Cluster registry meta-data address need to be fixed if you are running hyperkit docker under `Darwin`. Run following script to fix this.
-Specify the clusters you need to be fixed, Comma seperated.
-```bash
-./scripts/fix-joined-kind-clusters.sh cluster1,cluster2
-``` 
 
 ## Operations
 
@@ -138,6 +133,21 @@ Repeat this step to join any additional clusters.
 
 **NOTE:** `cluster-context` will default to use the joining cluster name if not
 specified.
+
+#### Joining kind clusters on MacOS
+
+A Kubernetes cluster deployed with [kind](https://sigs.k8s.io/kind) on Docker
+for MacOS will have an API endpoint of `https://localhost:<random-port>` in its
+kubeconfig context. Such an endpoint will be compatible with local invocations
+of cli tools like `kubectl`. The same endpoint will not be reachable from a
+KubeFed control plane, and the endpoints of kind clusters joined to a KubeFed
+control plane will need to be updated to `https://<kind pod ip>:6443`. This can
+be accomplished by executing the following script after a cluster is registered
+to the control plane with `kubefedctl join`.
+
+```bash
+./scripts/fix-joined-kind-clusters.sh
+```
 
 ### Checking status of joined clusters
 

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -23,7 +23,8 @@ set -o pipefail
 
 source "$(dirname "${BASH_SOURCE}")/util.sh"
 CREATE_INSECURE_REGISTRY="${CREATE_INSECURE_REGISTRY:-}"
-CONFIGURE_INSECURE_REGISTRY="${CONFIGURE_INSECURE_REGISTRY:-}"
+CONFIGURE_INSECURE_REGISTRY_HOST="${CONFIGURE_INSECURE_REGISTRY_HOST:-}"
+CONFIGURE_INSECURE_REGISTRY_CLUSTER="${CONFIGURE_INSECURE_REGISTRY_CLUSTER:-y}"
 CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 OVERWRITE_KUBECONFIG="${OVERWRITE_KUBECONFIG:-}"
@@ -50,7 +51,7 @@ EOF
       err=true
     fi
   elif pgrep -a dockerd | grep -q 'insecure-registry'; then
-    echo <<EOF "Error: CONFIGURE_INSECURE_REGISTRY=${CONFIGURE_INSECURE_REGISTRY} \
+    echo <<EOF "Error: CONFIGURE_INSECURE_REGISTRY_HOST=${CONFIGURE_INSECURE_REGISTRY_HOST} \
 and about to write ${docker_daemon_config}, but dockerd is already configured with \
 an 'insecure-registry' command line option. Please make the necessary changes or disable \
 the command line option and try again."
@@ -113,10 +114,12 @@ function create-clusters() {
     unset KUBECONFIG
   fi
 
-  # TODO(font): Configure insecure registry on kind host cluster. Remove once
-  # https://github.com/kubernetes-sigs/kind/issues/110 is resolved.
-  echo "Configuring insecure container registry on kind host cluster"
-  configure-insecure-registry-on-cluster 1
+  if [[ "${CONFIGURE_INSECURE_REGISTRY_CLUSTER}" ]]; then
+    # TODO(font): Configure insecure registry on kind host cluster. Remove once
+    # https://github.com/kubernetes-sigs/kind/issues/110 is resolved.
+    echo "Configuring insecure container registry on kind host cluster"
+    configure-insecure-registry-on-cluster 1
+  fi
 }
 
 function fixup-cluster() {
@@ -160,7 +163,7 @@ if [[ "${CREATE_INSECURE_REGISTRY}" ]]; then
   create-insecure-registry
 fi
 
-if [[ "${CONFIGURE_INSECURE_REGISTRY}" ]]; then
+if [[ "${CONFIGURE_INSECURE_REGISTRY_HOST}" ]]; then
   echo "Configuring container registry on host"
   configure-insecure-registry
 fi

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -42,6 +42,7 @@ dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
 platform=$(uname -s|tr A-Z a-z)
+
 kb_version="1.0.8"
 kb_tgz="kubebuilder_${kb_version}_${platform}_amd64.tar.gz"
 kb_url="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kb_version}/${kb_tgz}"
@@ -61,7 +62,7 @@ golint_dir="golangci-lint-${golint_version}-${platform}-amd64"
 golint_tgz="${golint_dir}.tar.gz"
 golint_url="https://github.com/golangci/golangci-lint/releases/download/v1.16.0/${golint_tgz}"
 curl "${curl_args}O" "${golint_url}" \
-    && tar xzfP "${golint_tgz}" -C "${dest_dir}" "${golint_dir}/golangci-lint" --strip-components=1 \
+    && tar xzfP "${golint_tgz}" -C "${dest_dir}" --strip-components=1 "${golint_dir}/golangci-lint" \
     && rm "${golint_tgz}"
 
 echo    "# destination:"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -137,7 +137,7 @@ run-unit-tests
 echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
-CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY=y OVERWRITE_KUBECONFIG=y \
+CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y OVERWRITE_KUBECONFIG=y \
     KIND_TAG="v1.14.0" ./scripts/create-clusters.sh
 
 # Initialize list of clusters to join


### PR DESCRIPTION
This is a follow-up to #706 to fix compatibility with the current state of the API and ensure the kind fixup script conforms to the bash conventions used by other scripts.

This PR also:

 - ensures that the `create-servers.sh` script does not attempt to configure a container registry if `CONFIGURE_CONTAINER_REGISTRY` is not set to ensure compatibility with a MacOS deployment environment that hosts the docker daemon in a VM.
 - fixes the download of `golangci-lint` on macos
 - adds support to the kind fixup script for e2e testing on macos with in-memory controllers