### PR TITLE
Rename and refactor validation admission webhooks

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
@@ -82,7 +82,7 @@ metadata:
 {{ end }}
 rules:
 - apiGroups:
-  - admission.core.kubefed.k8s.io
+  - validation.core.kubefed.k8s.io
   resources:
   - federatedtypeconfigs
   - kubefedclusters

--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -9,9 +9,9 @@ metadata:
 # For namespace scoped deployments, create a unique cluster-scoped resource
 # using the namespace.
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
-  name: validations.admission.core.kubefed.k8s.io-{{ .Release.Namespace }}
+  name: validations.core.kubefed.k8s.io-{{ .Release.Namespace }}
 {{ else }}
-  name: validations.admission.core.kubefed.k8s.io
+  name: validations.core.kubefed.k8s.io
 {{ end }}
 webhooks:
 - name: federatedtypeconfigs.core.kubefed.k8s.io
@@ -19,7 +19,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/admission.core.kubefed.k8s.io/v1beta1/federatedtypeconfigs
+      path: /apis/validation.core.kubefed.k8s.io/v1beta1/federatedtypeconfigs
     caBundle: {{ b64enc $ca.Cert | quote }}
   rules:
   - operations:
@@ -49,7 +49,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/admission.core.kubefed.k8s.io/v1beta1/kubefedclusters
+      path: /apis/validation.core.kubefed.k8s.io/v1beta1/kubefedclusters
     caBundle: {{ b64enc $ca.Cert | quote }}
   rules:
   - operations:
@@ -76,7 +76,7 @@ webhooks:
     service:
       namespace: {{ .Release.Namespace | quote }}
       name: kubefed-admission-webhook
-      path: /apis/admission.core.kubefed.k8s.io/v1beta1/kubefedconfigs
+      path: /apis/validation.core.kubefed.k8s.io/v1beta1/kubefedconfigs
     caBundle: {{ b64enc $ca.Cert | quote }}
   rules:
   - operations:

--- a/pkg/apis/core/v1beta1/validation/validation.go
+++ b/pkg/apis/core/v1beta1/validation/validation.go
@@ -25,7 +25,6 @@ import (
 	valutil "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/tools/leaderelection"
-	"k8s.io/klog"
 
 	"sigs.k8s.io/kubefed/pkg/apis/core/typeconfig"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
@@ -144,8 +143,6 @@ func ValidateFederatedTypeConfigStatus(status *v1beta1.FederatedTypeConfigStatus
 }
 
 func ValidateKubeFedConfig(kubeFedConfig *v1beta1.KubeFedConfig) field.ErrorList {
-	klog.V(2).Infof("Validating KubeFedConfig %q", kubeFedConfig.Name)
-
 	allErrs := field.ErrorList{}
 
 	spec := kubeFedConfig.Spec

--- a/pkg/controller/webhook/federatedtypeconfig/webhook.go
+++ b/pkg/controller/webhook/federatedtypeconfig/webhook.go
@@ -85,27 +85,5 @@ func (a *FederatedTypeConfigAdmissionHook) Validate(admissionSpec *admissionv1be
 }
 
 func (a *FederatedTypeConfigAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	a.initialized = true
-
-	shallowClientConfigCopy := *kubeClientConfig
-	shallowClientConfigCopy.GroupVersion = &schema.GroupVersion{
-		Group:   v1beta1.SchemeGroupVersion.Group,
-		Version: v1beta1.SchemeGroupVersion.Version,
-	}
-	shallowClientConfigCopy.APIPath = "/apis"
-	dynamicClient, err := dynamic.NewForConfig(&shallowClientConfigCopy)
-	if err != nil {
-		return err
-	}
-	a.client = dynamicClient.Resource(schema.GroupVersionResource{
-		Group:    v1beta1.SchemeGroupVersion.Group,
-		Version:  v1beta1.SchemeGroupVersion.Version,
-		Resource: resourceName,
-	})
-
-	klog.Infof("Initialized admission webhook for %q", resourceName)
-	return nil
+	return webhook.Initialize(kubeClientConfig, &a.client, &a.lock, &a.initialized, resourceName)
 }

--- a/pkg/controller/webhook/kubefedcluster/webhook.go
+++ b/pkg/controller/webhook/kubefedcluster/webhook.go
@@ -84,29 +84,5 @@ func (a *KubeFedClusterAdmissionHook) Validate(admissionSpec *admissionv1beta1.A
 }
 
 func (a *KubeFedClusterAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	a.initialized = true
-
-	shallowClientConfigCopy := *kubeClientConfig
-	shallowClientConfigCopy.GroupVersion = &schema.GroupVersion{
-		Group:   v1beta1.SchemeGroupVersion.Group,
-		Version: v1beta1.SchemeGroupVersion.Version,
-	}
-
-	shallowClientConfigCopy.APIPath = "/apis"
-	dynamicClient, err := dynamic.NewForConfig(&shallowClientConfigCopy)
-	if err != nil {
-		return err
-	}
-	a.client = dynamicClient.Resource(schema.GroupVersionResource{
-		Group:    v1beta1.SchemeGroupVersion.Group,
-		Version:  v1beta1.SchemeGroupVersion.Version,
-		Resource: resourceName,
-	})
-
-	klog.Infof("Initialized admission webhook for %q", resourceName)
-
-	return nil
+	return webhook.Initialize(kubeClientConfig, &a.client, &a.lock, &a.initialized, resourceName)
 }

--- a/pkg/controller/webhook/kubefedcluster/webhook.go
+++ b/pkg/controller/webhook/kubefedcluster/webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package webhook
+package kubefedcluster
 
 import (
 	"encoding/json"

--- a/pkg/controller/webhook/kubefedconfig/webhook.go
+++ b/pkg/controller/webhook/kubefedconfig/webhook.go
@@ -17,15 +17,13 @@ limitations under the License.
 package kubefedconfig
 
 import (
-	"encoding/json"
-	"net/http"
 	"strings"
 	"sync"
 
 	"github.com/openshift/generic-admission-server/pkg/apiserver"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
@@ -59,46 +57,26 @@ func (a *KubeFedConfigAdmissionHook) Validate(admissionSpec *admissionv1beta1.Ad
 
 	klog.V(4).Infof("Validating %q AdmissionRequest = %s", resourceName, webhook.AdmissionRequestDebugString(admissionSpec))
 
-	if webhook.Allowed(admissionSpec, resourcePluralName) {
-		status.Allowed = true
+	if webhook.Allowed(admissionSpec, resourcePluralName, status) {
 		return status
 	}
 
 	admittingObject := &v1beta1.KubeFedConfig{}
-	err := json.Unmarshal(admissionSpec.Object.Raw, admittingObject)
+	err := webhook.Unmarshal(admissionSpec, admittingObject, status)
 	if err != nil {
-		status.Allowed = false
-		status.Result = &metav1.Status{
-			Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
-			Message: err.Error(),
-		}
 		return status
 	}
 
-	a.lock.RLock()
-	defer a.lock.RUnlock()
-	if !a.initialized {
-		status.Allowed = false
-		status.Result = &metav1.Status{
-			Status: metav1.StatusFailure, Code: http.StatusInternalServerError, Reason: metav1.StatusReasonInternalError,
-			Message: "not initialized",
-		}
+	if !webhook.Initialized(&a.initialized, &a.lock, status) {
 		return status
 	}
 
 	klog.V(4).Infof("Validating %q = %+v", resourceName, *admittingObject)
 
-	errs := validation.ValidateKubeFedConfig(admittingObject)
-	if len(errs) != 0 {
-		status.Allowed = false
-		status.Result = &metav1.Status{
-			Status: metav1.StatusFailure, Code: http.StatusForbidden, Reason: metav1.StatusReasonForbidden,
-			Message: errs.ToAggregate().Error(),
-		}
-		return status
-	}
+	webhook.Validate(status, func() field.ErrorList {
+		return validation.ValidateKubeFedConfig(admittingObject)
+	})
 
-	status.Allowed = true
 	return status
 }
 

--- a/pkg/controller/webhook/kubefedconfig/webhook.go
+++ b/pkg/controller/webhook/kubefedconfig/webhook.go
@@ -81,27 +81,5 @@ func (a *KubeFedConfigAdmissionHook) Validate(admissionSpec *admissionv1beta1.Ad
 }
 
 func (a *KubeFedConfigAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
-	a.lock.Lock()
-	defer a.lock.Unlock()
-
-	a.initialized = true
-
-	shallowClientConfigCopy := *kubeClientConfig
-	shallowClientConfigCopy.GroupVersion = &schema.GroupVersion{
-		Group:   v1beta1.SchemeGroupVersion.Group,
-		Version: v1beta1.SchemeGroupVersion.Version,
-	}
-	shallowClientConfigCopy.APIPath = "/apis"
-	dynamicClient, err := dynamic.NewForConfig(&shallowClientConfigCopy)
-	if err != nil {
-		return err
-	}
-	a.client = dynamicClient.Resource(schema.GroupVersionResource{
-		Group:    v1beta1.SchemeGroupVersion.Group,
-		Version:  v1beta1.SchemeGroupVersion.Version,
-		Resource: resourceName,
-	})
-
-	klog.Infof("Initialized admission webhook for %q", resourceName)
-	return nil
+	return webhook.Initialize(kubeClientConfig, &a.client, &a.lock, &a.initialized, resourceName)
 }

--- a/pkg/controller/webhook/util.go
+++ b/pkg/controller/webhook/util.go
@@ -17,6 +17,8 @@ limitations under the License.
 package webhook
 
 import (
+	"fmt"
+
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -45,4 +47,9 @@ func Allowed(a *admissionv1beta1.AdmissionRequest, pluralResourceName string) bo
 	createOrUpdate := a.Operation == admissionv1beta1.Create || a.Operation == admissionv1beta1.Update
 	isMyGroupAndResource := a.Resource.Group == v1beta1.SchemeGroupVersion.Group && a.Resource.Resource == pluralResourceName
 	return !createOrUpdate || !isMyGroupAndResource
+}
+
+func AdmissionRequestDebugString(a *admissionv1beta1.AdmissionRequest) string {
+	return fmt.Sprintf("UID=%v Kind={%v} Resource=%+v SubResource=%v Name=%v Namespace=%v Operation=%v UserInfo=%+v DryRun=%v",
+		a.UID, a.Kind, a.Resource, a.SubResource, a.Name, a.Namespace, a.Operation, a.UserInfo, *a.DryRun)
 }

--- a/pkg/controller/webhook/util.go
+++ b/pkg/controller/webhook/util.go
@@ -24,14 +24,14 @@ import (
 )
 
 var (
-	validationGroup   = "admission." + v1beta1.SchemeGroupVersion.Group
-	validationVersion = v1beta1.SchemeGroupVersion.Version
+	validationGroup  = "validation." + v1beta1.SchemeGroupVersion.Group
+	admissionVersion = v1beta1.SchemeGroupVersion.Version
 )
 
 func NewValidatingResource(resourcePluralName string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{
 		Group:    validationGroup,
-		Version:  validationVersion,
+		Version:  admissionVersion,
 		Resource: resourcePluralName,
 	}
 }

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -23,15 +23,15 @@ import (
 	"github.com/openshift/generic-admission-server/pkg/cmd/server"
 	"github.com/spf13/cobra"
 
-	"sigs.k8s.io/kubefed/pkg/controller/webhook"
 	"sigs.k8s.io/kubefed/pkg/controller/webhook/federatedtypeconfig"
+	"sigs.k8s.io/kubefed/pkg/controller/webhook/kubefedcluster"
 	"sigs.k8s.io/kubefed/pkg/controller/webhook/kubefedconfig"
 )
 
 func NewWebhookCommand(stopChan <-chan struct{}) *cobra.Command {
 	admissionHooks := []apiserver.AdmissionHook{
 		&federatedtypeconfig.FederatedTypeConfigValidationHook{},
-		&webhook.KubeFedClusterValidationHook{},
+		&kubefedcluster.KubeFedClusterValidationHook{},
 		&kubefedconfig.KubeFedConfigValidationHook{},
 	}
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -30,9 +30,9 @@ import (
 
 func NewWebhookCommand(stopChan <-chan struct{}) *cobra.Command {
 	admissionHooks := []apiserver.AdmissionHook{
-		&federatedtypeconfig.FederatedTypeConfigValidationHook{},
-		&kubefedcluster.KubeFedClusterValidationHook{},
-		&kubefedconfig.KubeFedConfigValidationHook{},
+		&federatedtypeconfig.FederatedTypeConfigAdmissionHook{},
+		&kubefedcluster.KubeFedClusterAdmissionHook{},
+		&kubefedconfig.KubeFedConfigAdmissionHook{},
 	}
 
 	cmd := server.NewCommandStartAdmissionServer(os.Stdout, os.Stderr, stopChan, admissionHooks...)


### PR DESCRIPTION
This PR renames the `admission.core.kubefed.k8s.io` API group to `validation.core.kubefed.k8s.io`, and refactors the validating admission webhook interface methods in preparation for enabling mutating webhooks. It also adds more logs for debug purposes.