### PR TITLE
Add mutating webhook support for KubeFedConfig

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
@@ -89,3 +89,9 @@ rules:
   - kubefedconfigs
   verbs:
   - create
+- apiGroups:
+  - mutation.core.kubefed.k8s.io
+  resources:
+  - kubefedconfigs
+  verbs:
+  - create

--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -63,10 +63,7 @@ webhooks:
     - kubefedclusters
   failurePolicy: Fail
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
-# For namespace scoped deployments: filter admission webhook requests for
-# resources whose namespace matches the default namespace label applied by helm
-# upon creating the namespace. User must set this label manually if namespace
-# is created prior to installing chart with helm.
+# See comment above.
   namespaceSelector:
     matchLabels:
       name: {{ .Release.Namespace }}
@@ -90,10 +87,41 @@ webhooks:
     - kubefedconfigs
   failurePolicy: Fail
 {{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
-# For namespace scoped deployments: filter admission webhook requests for
-# resources whose namespace matches the default namespace label applied by helm
-# upon creating the namespace. User must set this label manually if namespace
-# is created prior to installing chart with helm.
+# See comment above.
+  namespaceSelector:
+    matchLabels:
+      name: {{ .Release.Namespace }}
+{{ end }}
+---
+# The same comments for ValidatingWebhookConfiguration apply here to
+# MutatingWebhookConfiguration.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
+  name: mutation.core.kubefed.k8s.io-{{ .Release.Namespace }}
+{{ else }}
+  name: mutation.core.kubefed.k8s.io
+{{ end }}
+webhooks:
+- name: kubefedconfigs.core.kubefed.k8s.io
+  clientConfig:
+    service:
+      namespace: {{ .Release.Namespace | quote }}
+      name: kubefed-admission-webhook
+      path: /apis/mutation.core.kubefed.k8s.io/v1beta1/kubefedconfigs
+    caBundle: {{ b64enc $ca.Cert | quote }}
+  rules:
+  - operations:
+    - CREATE
+    apiGroups:
+    - core.kubefed.k8s.io
+    apiVersions:
+    - v1beta1
+    resources:
+    - kubefedconfigs
+  failurePolicy: Fail
+{{- if and .Values.global.scope (eq .Values.global.scope "Namespaced") }}
   namespaceSelector:
     matchLabels:
       name: {{ .Release.Namespace }}

--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -302,7 +302,8 @@ func (c *Controller) startSyncController(tc *corev1b1.FederatedTypeConfig) error
 		return errors.Wrapf(err, "Unable to start sync controller for %q due to missing FederatedTypeConfig for namespaces", kind)
 	}
 	stopChan := make(chan struct{})
-	err = synccontroller.StartKubeFedSyncController(c.controllerConfig, stopChan, tc, fedNamespaceAPIResource)
+	ftc := tc.DeepCopyObject().(*corev1b1.FederatedTypeConfig)
+	err = synccontroller.StartKubeFedSyncController(c.controllerConfig, stopChan, ftc, fedNamespaceAPIResource)
 	if err != nil {
 		close(stopChan)
 		return errors.Wrapf(err, "Error starting sync controller for %q", kind)
@@ -317,7 +318,8 @@ func (c *Controller) startSyncController(tc *corev1b1.FederatedTypeConfig) error
 func (c *Controller) startStatusController(statusKey string, tc *corev1b1.FederatedTypeConfig) error {
 	kind := tc.Spec.FederatedType.Kind
 	stopChan := make(chan struct{})
-	err := statuscontroller.StartKubeFedStatusController(c.controllerConfig, stopChan, tc)
+	ftc := tc.DeepCopyObject().(*corev1b1.FederatedTypeConfig)
+	err := statuscontroller.StartKubeFedStatusController(c.controllerConfig, stopChan, ftc)
 	if err != nil {
 		close(stopChan)
 		return errors.Wrapf(err, "Error starting status controller for %q", kind)

--- a/pkg/controller/webhook/kubefedconfig/webhook.go
+++ b/pkg/controller/webhook/kubefedconfig/webhook.go
@@ -80,6 +80,35 @@ func (a *KubeFedConfigAdmissionHook) Validate(admissionSpec *admissionv1beta1.Ad
 	return status
 }
 
+var _ apiserver.MutatingAdmissionHook = &KubeFedConfigAdmissionHook{}
+
+func (a *KubeFedConfigAdmissionHook) MutatingResource() (plural schema.GroupVersionResource, singular string) {
+	klog.Infof("New MutatingResource for %q", resourceName)
+	return webhook.NewMutatingResource(resourcePluralName), strings.ToLower(resourceName)
+}
+
+func (a *KubeFedConfigAdmissionHook) Admit(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	status := &admissionv1beta1.AdmissionResponse{}
+	klog.V(4).Infof("Admitting %q AdmissionRequest = %s", resourceName, webhook.AdmissionRequestDebugString(admissionSpec))
+
+	admittingObject := &v1beta1.KubeFedConfig{}
+	err := webhook.Unmarshal(admissionSpec, admittingObject, status)
+	if err != nil {
+		return status
+	}
+
+	klog.V(4).Infof("Admitting %q = %+v", resourceName, *admittingObject)
+
+	if !webhook.Initialized(&a.initialized, &a.lock, status) {
+		return status
+	}
+
+	// TODO(font) add defaults
+
+	status.Allowed = true
+	return status
+}
+
 func (a *KubeFedConfigAdmissionHook) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
 	return webhook.Initialize(kubeClientConfig, &a.client, &a.lock, &a.initialized, resourceName)
 }

--- a/pkg/controller/webhook/util.go
+++ b/pkg/controller/webhook/util.go
@@ -35,8 +35,17 @@ import (
 
 var (
 	validationGroup  = "validation." + v1beta1.SchemeGroupVersion.Group
+	mutationGroup    = "mutation." + v1beta1.SchemeGroupVersion.Group
 	admissionVersion = v1beta1.SchemeGroupVersion.Version
 )
+
+func NewMutatingResource(resourcePluralName string) schema.GroupVersionResource {
+	return schema.GroupVersionResource{
+		Group:    mutationGroup,
+		Version:  admissionVersion,
+		Resource: resourcePluralName,
+	}
+}
 
 func NewValidatingResource(resourcePluralName string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{


### PR DESCRIPTION
~~**NOTE:** This PR is not reviewable until #977 merges.~~

This adds the initial support for a mutating webhook for `KubeFedConfig`. The subsequent work after this PR will involve adding the defaulting logic for `KubeFedConfig`.