### PR TITLE
Add Xun Pan as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,3 +14,4 @@ approvers:
   - marun
   - pmorie
   - shashidharatd
+  - xunpan


### PR DESCRIPTION
@xunpan has proven a solid contributor to KubeFed since he started last year and I believe that he has demonstrated the capability and commitment to the long-term success of the project that justify his elevation to the status of `approver`.