### PR TITLE
Add explanation, how to configure PSP for the kubefed namespace on ICP

### DIFF
--- a/docs/environments/icp.md
+++ b/docs/environments/icp.md
@@ -36,7 +36,7 @@ For the second cluster, set the following value in `cluster/config.yaml` as foll
 cluster_name: cluster2
 ```
 
-## Post Install Configuration
+## Pre Install Configuration
 
 As IBM Cloud Private is [enforcing container image security](https://www.ibm.com/support/knowledgecenter/SSBS6K_3.1.1/manage_images/image_security.html)
 policy by default, and the default image security policy does not allow pulling the KubeFed
@@ -55,5 +55,17 @@ spec:
     - name: "quay.io/kubernetes-multicluster/kubefed:*"
 ```
 
-Once all pods are running you can return to the [User Guide](../userguide.md) to deploy the
-KubeFed control-plane.
+IBM Cloud Private supports [pod isolation](https://www.ibm.com/support/knowledgecenter/SSBS6K_3.2.0/user_management/iso_pod.html) 
+with `ibm-restricted-psp` as the default pod security policy. This policy requires pods to run with a non-root user ID, 
+and prevents pods from accessing the host. The kubefed pods try to run as root, so the Pod Security Policy prevents their start.
+The simplest way to configure the Pod security policy for the `kube-federation-system` namespace, is to create and configure 
+the namespace before kubefed installation.
+
+1. Log in to your IBM Cloud Private cluster as a cluster administrator.
+2. From the navigation menu, click Manage > Namespaces.
+3. Click the Create Namespace button.
+4. In the Create Namespace dialog box, enter `kube-federation-system` as the name of the new namespace.
+5. Click the Pod Security drop-down menu and select `ibm-anyuid-psp`as pod security policy for your namespace.
+
+When you finish these operations, you can return to the [User Guide](../userguide.md) to deploy the KubeFed control-plane.
+

--- a/docs/environments/icp.md
+++ b/docs/environments/icp.md
@@ -4,7 +4,7 @@
 
 - [IBM Cloud Private Deployment Guide](#ibm-cloud-private-deployment-guide)
   - [Install IBM Cloud Private](#install-ibm-cloud-private)
-  - [Post Install Configuration](#post-install-configuration)
+  - [Pre KubeFed Install Configuration](#pre-kubefed-install-configuration)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -36,7 +36,7 @@ For the second cluster, set the following value in `cluster/config.yaml` as foll
 cluster_name: cluster2
 ```
 
-## Pre Install Configuration
+## Pre KubeFed Install Configuration
 
 As IBM Cloud Private is [enforcing container image security](https://www.ibm.com/support/knowledgecenter/SSBS6K_3.1.1/manage_images/image_security.html)
 policy by default, and the default image security policy does not allow pulling the KubeFed


### PR DESCRIPTION
IBM Private Cloud default PSP prevents running pods as `root`. This PR adds explanation how to configure ICP's PSP. 