### PR TITLE
when DOCKER_PUSH= is set, the script should skip docker push

### DIFF
--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -143,7 +143,7 @@ JOIN_CLUSTERS="${*-}"
 
 # Use DOCKER_PUSH= ./scripts/deploy-kubefed.sh <image> to skip docker
 # push on container image when not using latest image.
-DOCKER_PUSH="${DOCKER_PUSH:-y}"
+DOCKER_PUSH="${DOCKER_PUSH-y}"
 DOCKER_PUSH_CMD="docker push ${IMAGE_NAME}"
 if [[ ! "${DOCKER_PUSH}" ]]; then
     DOCKER_PUSH_CMD=


### PR DESCRIPTION
fix issues similar to #990. Use `-` instead of `:-` in variable expansion: when `DOCKER_PUSH` is set empty, the script should not set `y` but keep it as is.