### PR TITLE
configure images with a UID and set SC in deployments

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         kubefed-control-plane: controller-manager
     spec:
+      securityContext:
+        runAsUser: 1001
       serviceAccountName: kubefed-controller
       containers:
       - args:
@@ -60,6 +62,8 @@ spec:
       labels:
         kubefed-admission-webhook: "true"
     spec:
+      securityContext:
+        runAsUser: 1001
       serviceAccountName: kubefed-admission-webhook
       containers:
       - name: admission-webhook

--- a/images/kubefed/Dockerfile
+++ b/images/kubefed/Dockerfile
@@ -15,16 +15,17 @@
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-RUN adduser -D hyperfed
+RUN adduser -D -g hyperfed -u 1001 hyperfed
 
-RUN mkdir -p /hyperfed && \
-    chown -R hyperfed:hyperfed /hyperfed
+RUN mkdir -p /hyperfed
      
 WORKDIR /hyperfed/
 COPY /hyperfed .
 RUN ln -s hyperfed controller-manager \
  && ln -s hyperfed kubefedctl \
  && ln -s hyperfed webhook
+
+RUN chown -R hyperfed:hyperfed /hyperfed
 
 USER hyperfed
 ENTRYPOINT ["./controller-manager"]


### PR DESCRIPTION
- the hyperfed user is create with UID 1001
- the controller and webhook pods are run with a security context setting `runAsUser: 1001` so that kubernetes knows it's not running as a root user (supporting restricted pod security policies)
- also create the `hyperfed` user in a named group which seems to be required for `chown` to apply correctly
- also execute `chown` after copying binaries to hyperfed path as the binaries were ending up owned by `root` in my testing