### PR TITLE
Always retain metadata.finalizers and metadata.annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Unreleased
+-  [#982](https://github.com/kubernetes-sigs/kubefed/issues/982) To
+   ensure compatibility with controllers in member clusters,
+   metadata.finalizers and metadata.annotations can no longer be set
+   from the template of a federated resource and values for these
+   fields are always retained. The addition of jsonpatch overrides
+   ensures that it is still possible to add or remove entries from
+   these collections.
 -  [#1013](https://github.com/kubernetes-sigs/kubefed/issues/1013) Add support
    for defaulting KubeFedConfigs using mutating admission webhook.
 -  [#1038](https://github.com/kubernetes-sigs/kubefed/pull/1038) Removed template validation schema from Federated API's to facilitate upgrade scenarios.

--- a/pkg/controller/sync/dispatch/retain.go
+++ b/pkg/controller/sync/dispatch/retain.go
@@ -30,6 +30,12 @@ func RetainClusterFields(targetKind string, desiredObj, clusterObj, fedObj *unst
 	// Pass the same ResourceVersion as in the cluster object for update operation, otherwise operation will fail.
 	desiredObj.SetResourceVersion(clusterObj.GetResourceVersion())
 
+	// Retain finalizers and annotations since they will typically be set by
+	// controllers in a member cluster.  It is still possible to set the fields
+	// via overrides.
+	desiredObj.SetFinalizers(clusterObj.GetFinalizers())
+	desiredObj.SetAnnotations(clusterObj.GetAnnotations())
+
 	if targetKind == util.ServiceKind {
 		return retainServiceFields(desiredObj, clusterObj)
 	}

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -45,6 +45,7 @@ const (
 	ClusterNotReady        PropagationStatus = "ClusterNotReady"
 	CachedRetrievalFailed  PropagationStatus = "CachedRetrievalFailed"
 	ComputeResourceFailed  PropagationStatus = "ComputeResourceFailed"
+	ApplyOverridesFailed   PropagationStatus = "ApplyOverridesFailed"
 	CreationFailed         PropagationStatus = "CreationFailed"
 	UpdateFailed           PropagationStatus = "UpdateFailed"
 	DeletionFailed         PropagationStatus = "DeletionFailed"


### PR DESCRIPTION
Now that [overriding via jsonpatch is supported](https://github.com/kubernetes-sigs/kubefed/pull/991), it is possible to restrict modification of the `annotations` and `finalizers` fields to overrides. Modifications to these collection fields can be made using the `add` or `remove` jsonpatch operations to ensure that a given item exists (or does not exist) with less chance of conflicting with local controllers.

```yaml
kind: FederatedDeployment
...
spec:
  ...
  overrides:
    - clusterName: cluster1
      clusterOverrides:
        # Ensure the annotation "foo: bar" exists
        - path: "/metadata/annotations"
          op: "add"
          value:
            foo: bar
        # Ensure an annotation with key "foo" does not exist
        - path: "/metadata/annotations/foo"
          op: "remove"
```

To support this change, it was necessary to move the application of overrides from before retention of local values to after so  that overrides would be applied to the result of retention.

This change suggests implementing [selector-based overrides](https://github.com/kubernetes-sigs/kubefed/issues/581) to simplify applying an annotation across multiple clusters. 

Fixes #982 