### PR TITLE
Update install instructions for kubefedctl

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -67,10 +67,13 @@ For information about installing KubeFed, see the [installation documentation](.
 
 `kubefedctl` is the KubeFed command line utility. You can download
 the latest binary from the [release page](https://github.com/kubernetes-sigs/kubefed/releases).
+
 ```bash
-VERSION=<latest-version>
-curl -LO https://github.com/kubernetes-sigs/kubefed/releases/download/${VERSION}/kubefedctl.tgz
-tar -zxvf kubefedctl.tgz
+VERSION=<latest-version, e.g. 0.1.0-rc3>
+OS=<darwin/linux>
+ARCH=amd64
+curl -LO https://github.com/kubernetes-sigs/kubefed/releases/download/v${VERSION}/kubefedctl-${VERSION}-${OS}-${ARCH}.tgz
+tar -zxvf kubefedctl-*.tgz
 chmod u+x kubefedctl
 sudo mv kubefedctl /usr/local/bin/ # make sure the location is in the PATH
 ```
@@ -131,7 +134,8 @@ kubefedctl enable <target kubernetes API type>
 ```
 
 The `<target kubernetes API type>` can be any of the following
--  the Kind (e.g. `Deployment`)
+
+- the Kind (e.g. `Deployment`)
 - plural name (e.g. `deployments`)
 - group-qualified plural name (e.g `deployment.apps`), or
 - short name (e.g. `deploy`)


### PR DESCRIPTION
The release binaries have a new naming syntax compared with the old release.



Currently, the version specified in the path differs from the version specified in the file name, it may be something we want to look at/adjust going forward so we don't need to have the `v${VERSION}` in the path: