### PR TITLE
Kubefedcluster: support ignore tls

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/crds.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/crds.yaml
@@ -393,6 +393,14 @@ spec:
               description: CABundle contains the certificate authority information.
               format: byte
               type: string
+            disabledTLSValidations:
+              description: DisabledTLSValidations defines a list of checks to ignore
+                when validating the TLS connection to the member cluster.  This can
+                be any of *, SubjectName, or ValidityPeriod. If * is specified, it
+                is expected to be the only option in list.
+              items:
+                type: string
+              type: array
             secretRef:
               description: Name of the secret containing the token required to access
                 the member cluster. The secret needs to exist in the same namespace

--- a/pkg/apis/core/v1beta1/kubefedcluster_types.go
+++ b/pkg/apis/core/v1beta1/kubefedcluster_types.go
@@ -23,6 +23,14 @@ import (
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 )
 
+type TLSValidation string
+
+const (
+	TLSAll            TLSValidation = "*"
+	TLSSubjectName    TLSValidation = "SubjectName"
+	TLSValidityPeriod TLSValidation = "ValidityPeriod"
+)
+
 // KubeFedClusterSpec defines the desired state of KubeFedCluster
 type KubeFedClusterSpec struct {
 	// The API endpoint of the member cluster. This can be a hostname,
@@ -37,6 +45,12 @@ type KubeFedClusterSpec struct {
 	// member cluster. The secret needs to exist in the same namespace
 	// as the control plane and should have a "token" key.
 	SecretRef LocalSecretReference `json:"secretRef"`
+
+	// DisabledTLSValidations defines a list of checks to ignore when validating
+	// the TLS connection to the member cluster.  This can be any of *, SubjectName, or ValidityPeriod.
+	// If * is specified, it is expected to be the only option in list.
+	// +optional
+	DisabledTLSValidations []TLSValidation `json:"disabledTLSValidations,omitempty"`
 }
 
 // LocalSecretReference is a reference to a secret within the enclosing

--- a/pkg/apis/core/v1beta1/validation/validation_test.go
+++ b/pkg/apis/core/v1beta1/validation/validation_test.go
@@ -536,6 +536,55 @@ func TestValidateLocalSecretReference(t *testing.T) {
 	}
 }
 
+func TestDisabledTLSValidations(t *testing.T) {
+	testCases := []struct {
+		disabledTLSValidations []v1beta1.TLSValidation
+		expectedErr            bool
+		expectedErrMsg         string
+	}{
+		{
+			[]v1beta1.TLSValidation{},
+			false,
+			"",
+		},
+		{
+			[]v1beta1.TLSValidation{v1beta1.TLSAll},
+			false,
+			"",
+		},
+		{
+			[]v1beta1.TLSValidation{v1beta1.TLSSubjectName},
+			false,
+			"",
+		},
+		{
+			[]v1beta1.TLSValidation{v1beta1.TLSValidityPeriod},
+			false,
+			"",
+		},
+		{
+			[]v1beta1.TLSValidation{v1beta1.TLSSubjectName, v1beta1.TLSAll},
+			true,
+			"when * is specified, it is expected to be the only option in list",
+		},
+		{
+			[]v1beta1.TLSValidation{v1beta1.TLSAll, v1beta1.TLSValidityPeriod},
+			true,
+			"when * is specified, it is expected to be the only option in list",
+		},
+	}
+
+	for _, test := range testCases {
+		errs := validateDisabledTLSValidations(test.disabledTLSValidations, field.NewPath("disabledTLSValidations"))
+		hasErr := len(errs) > 0
+		if hasErr && hasErr != test.expectedErr {
+			t.Errorf("[%s] expected failure", test.expectedErrMsg)
+		} else if hasErr && !strings.Contains(errs[0].Error(), test.expectedErrMsg) {
+			t.Errorf("unexpected error: %v, expected: %q", errs[0].Error(), test.expectedErrMsg)
+		}
+	}
+}
+
 func TestValidateClusterCondition(t *testing.T) {
 	testCases := []struct {
 		cc             *v1beta1.ClusterCondition

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -317,6 +317,11 @@ func (in *KubeFedClusterSpec) DeepCopyInto(out *KubeFedClusterSpec) {
 		copy(*out, *in)
 	}
 	out.SecretRef = in.SecretRef
+	if in.DisabledTLSValidations != nil {
+		in, out := &in.DisabledTLSValidations, &out.DisabledTLSValidations
+		*out = make([]TLSValidation, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Implements an optional field in v1beta1/KubeFedCluster to specify which TLS checks to ignore. Disabling TLS checks is implemented by setting tls.Config.InsecureSkipVerify and providing a function closure implementing tls.Config.VerifyPeerCertificate (to selectively ignore SubjectName or ValidityPeriod).

Modifies kubefedctl join to preserve the kubeconfig cluster setting of InsecureSkipTLSVerify by setting the new field in v1beta1/KubeFedCluster.

Related issue:
https://github.com/kubernetes-sigs/kubefed/issues/1029