### PR TITLE
Use the controller QPS/Burst config for e2e tests

### DIFF
--- a/test/e2e/framework/unmanaged.go
+++ b/test/e2e/framework/unmanaged.go
@@ -117,6 +117,8 @@ func (f *UnmanagedFramework) BeforeEach() {
 		By("Reading cluster configuration")
 		var err error
 		f.Config, f.Kubeconfig, err = loadConfig(TestContext.KubeConfig, TestContext.KubeContext)
+		f.Config.QPS = util.KubeAPIQPS
+		f.Config.Burst = util.KubeAPIBurst
 		Expect(err).NotTo(HaveOccurred())
 	}
 }


### PR DESCRIPTION
This reduces the incidence of unnecessary throttling at test time.  I only noticed this by setting `-v=4` when running tests.