### PR TITLE
Update KubeFedCluster API optional fields

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/crds.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/crds.yaml
@@ -455,6 +455,8 @@ spec:
           required:
           - conditions
           type: object
+      required:
+      - spec
   version: v1beta1
 status:
   acceptedNames:

--- a/pkg/apis/core/v1beta1/kubefedcluster_types.go
+++ b/pkg/apis/core/v1beta1/kubefedcluster_types.go
@@ -57,7 +57,7 @@ type KubeFedClusterStatus struct {
 	Zones []string `json:"zones,omitempty"`
 	// Region is the name of the region in which all of the nodes in the cluster exist.  e.g. 'us-east1'.
 	// +optional
-	Region string `json:"region,omitempty"`
+	Region *string `json:"region,omitempty"`
 }
 
 // +genclient
@@ -76,7 +76,8 @@ type KubeFedCluster struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   KubeFedClusterSpec   `json:"spec,omitempty"`
+	Spec KubeFedClusterSpec `json:"spec"`
+	// +optional
 	Status KubeFedClusterStatus `json:"status,omitempty"`
 }
 
@@ -90,13 +91,13 @@ type ClusterCondition struct {
 	LastProbeTime metav1.Time `json:"lastProbeTime"`
 	// Last time the condition transit from one status to another.
 	// +optional
-	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
 	// (brief) reason for the condition's last transition.
 	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason *string `json:"reason,omitempty"`
 	// Human readable message indicating details about last transition.
 	// +optional
-	Message string `json:"message,omitempty"`
+	Message *string `json:"message,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/core/v1beta1/zz_generated.deepcopy.go
@@ -45,7 +45,20 @@ func (in *APIResource) DeepCopy() *APIResource {
 func (in *ClusterCondition) DeepCopyInto(out *ClusterCondition) {
 	*out = *in
 	in.LastProbeTime.DeepCopyInto(&out.LastProbeTime)
-	in.LastTransitionTime.DeepCopyInto(&out.LastTransitionTime)
+	if in.LastTransitionTime != nil {
+		in, out := &in.LastTransitionTime, &out.LastTransitionTime
+		*out = (*in).DeepCopy()
+	}
+	if in.Reason != nil {
+		in, out := &in.Reason, &out.Reason
+		*out = new(string)
+		**out = **in
+	}
+	if in.Message != nil {
+		in, out := &in.Message, &out.Message
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -344,6 +357,11 @@ func (in *KubeFedClusterStatus) DeepCopyInto(out *KubeFedClusterStatus) {
 		in, out := &in.Zones, &out.Zones
 		*out = make([]string, len(*in))
 		copy(*out, *in)
+	}
+	if in.Region != nil {
+		in, out := &in.Region, &out.Region
+		*out = new(string)
+		**out = **in
 	}
 	return
 }

--- a/pkg/controller/kubefedcluster/clusterclient.go
+++ b/pkg/controller/kubefedcluster/clusterclient.go
@@ -42,6 +42,16 @@ const (
 	// Following labels come from k8s.io/kubernetes/pkg/kubelet/apis
 	LabelZoneFailureDomain = "failure-domain.beta.kubernetes.io/zone"
 	LabelZoneRegion        = "failure-domain.beta.kubernetes.io/region"
+
+	// Common ClusterConditions for KubeFedClusterStatus
+	ClusterReady              = "ClusterReady"
+	HealthzOk                 = "/healthz responded with ok"
+	ClusterNotReady           = "ClusterNotReady"
+	HealthzNotOk              = "/healthz responded without ok"
+	ClusterNotReachableReason = "ClusterNotReachable"
+	ClusterNotReachableMsg    = "cluster is not reachable"
+	ClusterReachableReason    = "ClusterReachable"
+	ClusterReachableMsg       = "cluster is reachable"
 )
 
 // ClusterClient provides methods for determining the status and zones of a
@@ -74,37 +84,45 @@ func NewClusterClientSet(c *fedv1b1.KubeFedCluster, client generic.Client, fedNa
 func (self *ClusterClient) GetClusterHealthStatus() *fedv1b1.KubeFedClusterStatus {
 	clusterStatus := fedv1b1.KubeFedClusterStatus{}
 	currentTime := metav1.Now()
+	clusterReady := ClusterReady
+	healthzOk := HealthzOk
 	newClusterReadyCondition := fedv1b1.ClusterCondition{
 		Type:               fedcommon.ClusterReady,
 		Status:             corev1.ConditionTrue,
-		Reason:             "ClusterReady",
-		Message:            "/healthz responded with ok",
+		Reason:             &clusterReady,
+		Message:            &healthzOk,
 		LastProbeTime:      currentTime,
-		LastTransitionTime: currentTime,
+		LastTransitionTime: &currentTime,
 	}
+	clusterNotReady := ClusterNotReady
+	healthzNotOk := HealthzNotOk
 	newClusterNotReadyCondition := fedv1b1.ClusterCondition{
 		Type:               fedcommon.ClusterReady,
 		Status:             corev1.ConditionFalse,
-		Reason:             "ClusterNotReady",
-		Message:            "/healthz responded without ok",
+		Reason:             &clusterNotReady,
+		Message:            &healthzNotOk,
 		LastProbeTime:      currentTime,
-		LastTransitionTime: currentTime,
+		LastTransitionTime: &currentTime,
 	}
+	clusterNotReachableReason := ClusterNotReachableReason
+	clusterNotReachableMsg := ClusterNotReachableMsg
 	newClusterOfflineCondition := fedv1b1.ClusterCondition{
 		Type:               fedcommon.ClusterOffline,
 		Status:             corev1.ConditionTrue,
-		Reason:             "ClusterNotReachable",
-		Message:            "cluster is not reachable",
+		Reason:             &clusterNotReachableReason,
+		Message:            &clusterNotReachableMsg,
 		LastProbeTime:      currentTime,
-		LastTransitionTime: currentTime,
+		LastTransitionTime: &currentTime,
 	}
+	clusterReachableReason := ClusterReachableReason
+	clusterReachableMsg := ClusterReachableMsg
 	newClusterNotOfflineCondition := fedv1b1.ClusterCondition{
 		Type:               fedcommon.ClusterOffline,
 		Status:             corev1.ConditionFalse,
-		Reason:             "ClusterReachable",
-		Message:            "cluster is reachable",
+		Reason:             &clusterReachableReason,
+		Message:            &clusterReachableMsg,
 		LastProbeTime:      currentTime,
-		LastTransitionTime: currentTime,
+		LastTransitionTime: &currentTime,
 	}
 	body, err := self.kubeClient.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
 	if err != nil {

--- a/pkg/controller/kubefedcluster/controller.go
+++ b/pkg/controller/kubefedcluster/controller.go
@@ -255,7 +255,7 @@ func thresholdAdjustedClusterStatus(clusterStatus *fedv1b1.KubeFedClusterStatus,
 	} else {
 		if clusterStatusEqual(clusterStatus, storedData.clusterStatus) {
 			// preserve the last transition time
-			setTransitionTime(clusterStatus, storedData.clusterStatus.Conditions[0].LastTransitionTime)
+			setTransitionTime(clusterStatus, *storedData.clusterStatus.Conditions[0].LastTransitionTime)
 		}
 	}
 
@@ -288,11 +288,11 @@ func updateClusterZonesAndRegion(clusterStatus *fedv1b1.KubeFedClusterStatus, cl
 	if len(zones) == 0 {
 		zones = cluster.Status.Zones
 	}
-	if len(region) == 0 {
-		region = cluster.Status.Region
+	if len(region) == 0 && cluster.Status.Region != nil {
+		region = *cluster.Status.Region
 	}
 	clusterStatus.Zones = zones
-	clusterStatus.Region = region
+	clusterStatus.Region = &region
 	return clusterStatus
 }
 
@@ -308,6 +308,6 @@ func setProbeTime(clusterStatus *fedv1b1.KubeFedClusterStatus, probeTime metav1.
 
 func setTransitionTime(clusterStatus *fedv1b1.KubeFedClusterStatus, transitionTime metav1.Time) {
 	for i := 0; i < len(clusterStatus.Conditions); i++ {
-		clusterStatus.Conditions[i].LastTransitionTime = transitionTime
+		clusterStatus.Conditions[i].LastTransitionTime = &transitionTime
 	}
 }

--- a/pkg/controller/kubefedcluster/controller_test.go
+++ b/pkg/controller/kubefedcluster/controller_test.go
@@ -110,7 +110,7 @@ func clusterStatus(status corev1.ConditionStatus, lastProbeTime, lastTransitionT
 			Type:               common.ClusterReady,
 			Status:             status,
 			LastProbeTime:      lastProbeTime,
-			LastTransitionTime: lastTransitionTime,
+			LastTransitionTime: &lastTransitionTime,
 		}},
 	}
 }

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -302,13 +302,13 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 	var fedDNSStatus []dnsv1a1.ClusterDNS
 	// Iterate through all ready clusters and aggregate the service status for the key
 	for _, cluster := range clusters {
-		if cluster.Status.Region == "" || len(cluster.Status.Zones) == 0 {
+		if cluster.Status.Region == nil || *cluster.Status.Region == "" || len(cluster.Status.Zones) == 0 {
 			runtime.HandleError(errors.Wrapf(err, "Cluster %q does not have Region or Zones Attributes", cluster.Name))
 			return util.StatusError
 		}
 		clusterDNS := dnsv1a1.ClusterDNS{
 			Cluster: cluster.Name,
-			Region:  cluster.Status.Region,
+			Region:  *cluster.Status.Region,
 			Zones:   cluster.Status.Zones,
 		}
 

--- a/test/common/validation.go
+++ b/test/common/validation.go
@@ -24,10 +24,20 @@ import (
 
 	"sigs.k8s.io/kubefed/pkg/apis/core/common"
 	"sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/kubefed/pkg/controller/kubefedcluster"
 )
 
 func ValidKubeFedCluster() *v1beta1.KubeFedCluster {
 	lastProbeTime := time.Now()
+	clusterReady := kubefedcluster.ClusterReady
+	healthzOk := kubefedcluster.HealthzOk
+	clusterNotReady := kubefedcluster.ClusterNotReady
+	healthzNotOk := kubefedcluster.HealthzNotOk
+	clusterNotReachableReason := kubefedcluster.ClusterNotReachableReason
+	clusterNotReachableMsg := kubefedcluster.ClusterNotReachableMsg
+	clusterReachableReason := kubefedcluster.ClusterReachableReason
+	clusterReachableMsg := kubefedcluster.ClusterReachableMsg
+	region := "us-west1"
 	return &v1beta1.KubeFedCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "validation-test-cluster",
@@ -46,11 +56,35 @@ func ValidKubeFedCluster() *v1beta1.KubeFedCluster {
 					LastProbeTime: metav1.Time{
 						Time: lastProbeTime,
 					},
-					LastTransitionTime: metav1.Time{
+					LastTransitionTime: &metav1.Time{
 						Time: lastProbeTime,
 					},
-					Reason:  "ClusterReady",
-					Message: "/healthz responded with ok",
+					Reason:  &clusterReady,
+					Message: &healthzOk,
+				},
+				{
+					Type:   common.ClusterReady,
+					Status: corev1.ConditionFalse,
+					LastProbeTime: metav1.Time{
+						Time: lastProbeTime,
+					},
+					LastTransitionTime: &metav1.Time{
+						Time: lastProbeTime,
+					},
+					Reason:  &clusterNotReady,
+					Message: &healthzNotOk,
+				},
+				{
+					Type:   common.ClusterOffline,
+					Status: corev1.ConditionTrue,
+					LastProbeTime: metav1.Time{
+						Time: lastProbeTime,
+					},
+					LastTransitionTime: &metav1.Time{
+						Time: lastProbeTime,
+					},
+					Reason:  &clusterNotReachableReason,
+					Message: &clusterNotReachableMsg,
 				},
 				{
 					Type:   common.ClusterOffline,
@@ -58,15 +92,15 @@ func ValidKubeFedCluster() *v1beta1.KubeFedCluster {
 					LastProbeTime: metav1.Time{
 						Time: lastProbeTime,
 					},
-					LastTransitionTime: metav1.Time{
+					LastTransitionTime: &metav1.Time{
 						Time: lastProbeTime,
 					},
-					Reason:  "ClusterReachable",
-					Message: "cluster is reachable",
+					Reason:  &clusterReachableReason,
+					Message: &clusterReachableMsg,
 				},
 			},
 			Zones:  []string{"us-west1-a", "us-west1-b"},
-			Region: "us-west1",
+			Region: &region,
 		},
 	}
 }

--- a/test/e2e/servicedns.go
+++ b/test/e2e/servicedns.go
@@ -94,7 +94,7 @@ var _ = Describe("ServiceDNS", func() {
 		for _, clusterName := range f.ClusterNames(userAgent) {
 			serviceDNSStatus.DNS = append(serviceDNSStatus.DNS, dnsv1a1.ClusterDNS{
 				Cluster: clusterName,
-				Region:  clusterRegionZones[clusterName].Region,
+				Region:  *clusterRegionZones[clusterName].Region,
 				Zones:   clusterRegionZones[clusterName].Zones,
 			})
 		}
@@ -139,7 +139,7 @@ var _ = Describe("ServiceDNS", func() {
 			endpoints := []*dnsv1a1.Endpoint{}
 			for _, cluster := range serviceDNS.Status.DNS {
 				zones := clusterRegionZones[cluster.Cluster].Zones
-				region := clusterRegionZones[cluster.Cluster].Region
+				region := *clusterRegionZones[cluster.Cluster].Region
 				lbs := dnsendpoint.ExtractLoadBalancerTargets(cluster.LoadBalancer)
 
 				endpoint := common.NewDNSEndpoint(
@@ -188,7 +188,7 @@ func createClusterServiceAndEndpoints(f framework.KubeFedFramework, name, namesp
 		serviceDNSStatus.DNS = append(serviceDNSStatus.DNS, dnsv1a1.ClusterDNS{
 			Cluster:      clusterName,
 			LoadBalancer: loadbalancerStatus,
-			Region:       clusterRegionZones[clusterName].Region,
+			Region:       *clusterRegionZones[clusterName].Region,
 			Zones:        clusterRegionZones[clusterName].Zones,
 		})
 
@@ -226,7 +226,8 @@ func ensureClustersHaveRegionZoneAttributes(tl common.TestLogger, client generic
 	clusterRegionZones := make(map[string]fedv1b1.KubeFedClusterStatus)
 	for i, cluster := range clusters.Items {
 		err := wait.PollImmediate(framework.PollInterval, framework.TestContext.SingleCallTimeout, func() (bool, error) {
-			cluster.Status.Region = fmt.Sprintf("r%d", i)
+			region := fmt.Sprintf("r%d", i)
+			cluster.Status.Region = &region
 			cluster.Status.Zones = []string{fmt.Sprintf("z%d", i)}
 
 			err := client.UpdateStatus(context.TODO(), &cluster)


### PR DESCRIPTION
This updates the optional fields in `KubeFedClusterStatus` to make them pointers. It also makes `KubeFedClusterSpec` required as it was inadvertently changed previously.

Additionally, a couple more cluster conditions are added to the shared `ValidKubeFedCluster` test object (to complete all 4 possible conditions) as a result of changes for this PR.