### PR TITLE
Update release script and doc

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -47,7 +47,10 @@ Creating a KubeFed release involves the following steps:
       next to the sha256 digest under the `MANIFEST` column to indicate that
       the image tags `latest` and `<tag>` are identical. Hovering over this
       "link" symbol shows the tags having the same common image.
-4. Build the release artifacts (will output to root of repo)
+4. Build the release artifacts (will output to root of repo).
+   - Make sure `helm` is in your `PATH`. If not, execute:
+     - `./scripts/download-binaries.sh`
+     - `export PATH=$(pwd)/bin:${PATH}`
    - `./scripts/build-release-artifacts.sh <tag>`
 5. Create github release
    1. Copy text from old release and replace old tag references


### PR DESCRIPTION
Update the release doc to verify `helm` is installed prior to executing the release script. Also updates the release script for:
- new Makefile build targets after merging of #1039
- adds a check for `helm` being installed.