### PR TITLE
Support varying the apiVersion of target resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
+-  [#1052](https://github.com/kubernetes-sigs/kubefed/pull/1052)
+   Support has been added for varying the `apiVersion` of target
+   resources. This is intended to allow a federated type to manage
+   more than one version of the target type across member clusters.
+   `apiVersion` can be set either in the template of a federated
+   resource or via override.
 -  [#951](https://github.com/kubernetes-sigs/kubefed/issues/951)
    Propagation status for a namespaced federated resource whose
    containing namespace is not federated now indicates an unhealthy

--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -34,6 +34,8 @@ type Client interface {
 	Delete(ctx context.Context, obj runtime.Object, namespace, name string) error
 	List(ctx context.Context, obj runtime.Object, namespace string) error
 	UpdateStatus(ctx context.Context, obj runtime.Object) error
+
+	ListWithOptions(ctx context.Context, opts *client.ListOptions, obj runtime.Object) error
 }
 
 type genericClient struct {
@@ -83,6 +85,10 @@ func (c *genericClient) Delete(ctx context.Context, obj runtime.Object, namespac
 
 func (c *genericClient) List(ctx context.Context, obj runtime.Object, namespace string) error {
 	return c.client.List(ctx, &client.ListOptions{Namespace: namespace}, obj)
+}
+
+func (c *genericClient) ListWithOptions(ctx context.Context, opts *client.ListOptions, obj runtime.Object) error {
+	return c.client.List(ctx, opts, obj)
 }
 
 func (c *genericClient) UpdateStatus(ctx context.Context, obj runtime.Object) error {

--- a/pkg/controller/sync/dispatch/operation.go
+++ b/pkg/controller/sync/dispatch/operation.go
@@ -24,11 +24,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 
+	"sigs.k8s.io/kubefed/pkg/client/generic"
 	"sigs.k8s.io/kubefed/pkg/controller/sync/status"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
 
-type clientAccessorFunc func(clusterName string) (util.ResourceClient, error)
+type clientAccessorFunc func(clusterName string) (generic.Client, error)
 
 type dispatchRecorder interface {
 	recordEvent(clusterName, operation, operationContinuous string)
@@ -91,9 +92,8 @@ func (d *operationDispatcherImpl) Wait() (bool, error) {
 	return ok, nil
 }
 
-func (d *operationDispatcherImpl) clusterOperation(clusterName, op string, opFunc func(util.ResourceClient) util.ReconciliationStatus) {
-	// TODO(marun) Update to generic client and support cancellation
-	// on timeout.
+func (d *operationDispatcherImpl) clusterOperation(clusterName, op string, opFunc func(generic.Client) util.ReconciliationStatus) {
+	// TODO(marun) Support cancellation of client calls on timeout.
 	client, err := d.clientAccessor(clusterName)
 	if err != nil {
 		wrappedErr := errors.Wrapf(err, "Error retrieving client for cluster")

--- a/pkg/controller/util/overrides.go
+++ b/pkg/controller/util/overrides.go
@@ -52,10 +52,19 @@ type GenericOverride struct {
 // Namespace and name may not be overridden since these fields are the
 // primary mechanism of association between a federated resource in
 // the host cluster and the target resources in the member clusters.
+//
+// Kind should always be sourced from the FTC and not vary across
+// member clusters.
+//
+// apiVersion can be overridden to support managing resources like
+// Ingress which can exist in different groups at different
+// versions. Users will need to take care not to abuse this
+// capability.
 var invalidPaths = sets.NewString(
 	"/metadata/namespace",
 	"/metadata/name",
 	"/metadata/generateName",
+	"/kind",
 )
 
 // Slice of ClusterOverride

--- a/pkg/controller/util/podanalyzer/pod_helper.go
+++ b/pkg/controller/util/podanalyzer/pod_helper.go
@@ -17,11 +17,9 @@ limitations under the License.
 package podanalyzer
 
 import (
-	"encoding/json"
 	"time"
 
 	api_v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 type PodAnalysisResult struct {
@@ -43,16 +41,9 @@ const (
 // AnalyzePods calculates how many pods from the list are in one of
 // the meaningful (from the replica set perspective) states. This function is
 // a temporary workaround against the current lack of ownerRef in pods.
-func AnalyzePods(podList *unstructured.UnstructuredList, currentTime time.Time) PodAnalysisResult {
+func AnalyzePods(podList *api_v1.PodList, currentTime time.Time) PodAnalysisResult {
 	result := PodAnalysisResult{}
-	for _, unstructuredPod := range podList.Items {
-		content, _ := unstructuredPod.MarshalJSON()
-		pod := api_v1.Pod{}
-		err := json.Unmarshal(content, &pod)
-		if err != nil {
-			return result
-		}
-
+	for _, pod := range podList.Items {
 		result.Total++
 		for _, condition := range pod.Status.Conditions {
 			if pod.Status.Phase == api_v1.PodRunning {

--- a/pkg/controller/util/podanalyzer/pod_helper_test.go
+++ b/pkg/controller/util/podanalyzer/pod_helper_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package podanalyzer
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 
 	api_v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func TestAnalyze(t *testing.T) {
@@ -58,14 +56,14 @@ func TestAnalyze(t *testing.T) {
 			Conditions: []api_v1.PodCondition{},
 		})
 
-	result := AnalyzePods(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{*podRunning, *podRunning, *podRunning, *podUnschedulable, *podUnschedulable}}, now)
+	result := AnalyzePods(&api_v1.PodList{Items: []api_v1.Pod{*podRunning, *podRunning, *podRunning, *podUnschedulable, *podUnschedulable}}, now)
 	assert.Equal(t, PodAnalysisResult{
 		Total:           5,
 		RunningAndReady: 3,
 		Unschedulable:   2,
 	}, result)
 
-	result = AnalyzePods(&unstructured.UnstructuredList{Items: []unstructured.Unstructured{*podOther}}, now)
+	result = AnalyzePods(&api_v1.PodList{Items: []api_v1.Pod{*podOther}}, now)
 	assert.Equal(t, PodAnalysisResult{
 		Total:           1,
 		RunningAndReady: 0,
@@ -73,8 +71,8 @@ func TestAnalyze(t *testing.T) {
 	}, result)
 }
 
-func newPod(t *testing.T, name string, status api_v1.PodStatus) *unstructured.Unstructured {
-	pod := &api_v1.Pod{
+func newPod(t *testing.T, name string, status api_v1.PodStatus) *api_v1.Pod {
+	return &api_v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "pod",
 			APIVersion: "v1",
@@ -85,11 +83,4 @@ func newPod(t *testing.T, name string, status api_v1.PodStatus) *unstructured.Un
 		},
 		Status: status,
 	}
-
-	uP := &unstructured.Unstructured{}
-	pMarshalled, err := json.Marshal(pod)
-	assert.NoError(t, err)
-	assert.NoError(t, uP.UnmarshalJSON(pMarshalled))
-
-	return uP
 }

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -57,10 +57,12 @@ curl "${curl_args}O" "${helm_url}" \
     && tar xzfp "${helm_tgz}" -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm" \
     && rm "${helm_tgz}"
 
-golint_version="1.16.0"
+# TODO(marun) Update to newer version of golangci-lint when
+# https://github.com/golangci/golangci-lint/issues/483 is fixed.
+golint_version="1.15.0"
 golint_dir="golangci-lint-${golint_version}-${platform}-amd64"
 golint_tgz="${golint_dir}.tar.gz"
-golint_url="https://github.com/golangci/golangci-lint/releases/download/v1.16.0/${golint_tgz}"
+golint_url="https://github.com/golangci/golangci-lint/releases/download/v${golint_version}/${golint_tgz}"
 curl "${curl_args}O" "${golint_url}" \
     && tar xzfP "${golint_tgz}" -C "${dest_dir}" --strip-components=1 "${golint_dir}/golangci-lint" \
     && rm "${golint_tgz}"


### PR DESCRIPTION
Previously the sync controller used `ResourceClient` to make changes to member clusters. This meant that the API endpoint configuration for a target type was always sourced from an FTC.

This PR updates the sync controller to use `GenericClient` so that API endpoint configuration for create and update calls can be provided on a per-call basis. If `apiVersion` is set via template or override for a given federated resource, that value will supersede the configuration sourced from an FTC. This is intended to allow a given federated type to manage more than one version across member clusters. For example, federated resource `foo` could manage a resource in cluster1 at v1, and a resource in cluster2 at v2. It would still be necessary for all clusters to support the version defined in the FTC since that is what would configure the informers for member clusters.