### PR TITLE
Make KubeFedConfig scope immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+-  [#1058](https://github.com/kubernetes-sigs/kubefed/issues/1058)
+   KubeFedConfig spec.scope is now immutable.
 -  [#1052](https://github.com/kubernetes-sigs/kubefed/pull/1052)
    Support has been added for varying the `apiVersion` of target
    resources. This is intended to allow a federated type to manage

--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -308,7 +308,7 @@ func setOptionsByKubeFedConfig(opts *options.Options) {
 	// file or already existing before the defaulting and validation webhook
 	// was registered e.g. prior to installation, upgrading, or due to issue
 	// https://github.com/kubernetes-sigs/kubefed/issues/983.
-	errs := validation.ValidateKubeFedConfig(fedConfig)
+	errs := validation.ValidateKubeFedConfig(fedConfig, nil)
 	if len(errs) != 0 {
 		klog.Fatalf("Error: invalid KubeFedConfig %q: %v", qualifedName, errs)
 	} else {

--- a/pkg/apis/core/v1beta1/validation/validation.go
+++ b/pkg/apis/core/v1beta1/validation/validation.go
@@ -254,13 +254,18 @@ func validateClusterCondition(cc *v1beta1.ClusterCondition, path *field.Path) fi
 	return allErrs
 }
 
-func ValidateKubeFedConfig(kubeFedConfig *v1beta1.KubeFedConfig) field.ErrorList {
+func ValidateKubeFedConfig(kubeFedConfig, oldKubeFedConfig *v1beta1.KubeFedConfig) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	spec := kubeFedConfig.Spec
 	specPath := field.NewPath("spec")
 	allErrs = append(allErrs, validateEnumStrings(specPath.Child("scope"), string(spec.Scope),
 		[]string{string(apiextv1b1.ClusterScoped), string(apiextv1b1.NamespaceScoped)})...)
+
+	if oldKubeFedConfig != nil {
+		// We are validating a KubeFedConfig update.
+		allErrs = append(allErrs, apimachineryval.ValidateImmutableField(spec.Scope, oldKubeFedConfig.Spec.Scope, specPath.Child("scope"))...)
+	}
 
 	duration := spec.ControllerDuration
 	durationPath := specPath.Child("controllerDuration")

--- a/pkg/apis/core/v1beta1/validation/validation_test.go
+++ b/pkg/apis/core/v1beta1/validation/validation_test.go
@@ -666,7 +666,7 @@ func TestValidateClusterCondition(t *testing.T) {
 }
 
 func TestValidateKubeFedConfig(t *testing.T) {
-	errs := ValidateKubeFedConfig(validKubeFedConfig())
+	errs := ValidateKubeFedConfig(validKubeFedConfig(), validKubeFedConfig())
 	if len(errs) != 0 {
 		t.Errorf("expected success: %v", errs)
 	}
@@ -676,6 +676,10 @@ func TestValidateKubeFedConfig(t *testing.T) {
 	invalidScope := validKubeFedConfig()
 	invalidScope.Spec.Scope = "NeitherClusterOrNamespaceScoped"
 	errorCases["spec.scope: Unsupported value"] = invalidScope
+
+	immutableScope := validKubeFedConfig()
+	immutableScope.Spec.Scope = apiextv1b1.NamespaceScoped
+	errorCases[`spec.scope: Invalid value: "Namespaced": field is immutable`] = immutableScope
 
 	invalidControllerDurationNil := validKubeFedConfig()
 	invalidControllerDurationNil.Spec.ControllerDuration = nil
@@ -819,7 +823,7 @@ func TestValidateKubeFedConfig(t *testing.T) {
 	errorCases["spec.syncController.adoptResources: Unsupported value"] = invalidAdoptResources
 
 	for k, v := range errorCases {
-		errs := ValidateKubeFedConfig(v)
+		errs := ValidateKubeFedConfig(v, validKubeFedConfig())
 		if len(errs) == 0 {
 			t.Errorf("[%s] expected failure", k)
 		} else if !strings.Contains(errs[0].Error(), k) {

--- a/pkg/controller/webhook/federatedtypeconfig/webhook.go
+++ b/pkg/controller/webhook/federatedtypeconfig/webhook.go
@@ -65,7 +65,7 @@ func (a *FederatedTypeConfigAdmissionHook) Validate(admissionSpec *admissionv1be
 	}
 
 	admittingObject := &v1beta1.FederatedTypeConfig{}
-	err := webhook.Unmarshal(admissionSpec, admittingObject, status)
+	err := webhook.Unmarshal(&admissionSpec.Object, admittingObject, status)
 	if err != nil {
 		return status
 	}

--- a/pkg/controller/webhook/kubefedcluster/webhook.go
+++ b/pkg/controller/webhook/kubefedcluster/webhook.go
@@ -65,7 +65,7 @@ func (a *KubeFedClusterAdmissionHook) Validate(admissionSpec *admissionv1beta1.A
 	}
 
 	admittingObject := &v1beta1.KubeFedCluster{}
-	err := webhook.Unmarshal(admissionSpec, admittingObject, status)
+	err := webhook.Unmarshal(&admissionSpec.Object, admittingObject, status)
 	if err != nil {
 		return status
 	}

--- a/pkg/controller/webhook/util.go
+++ b/pkg/controller/webhook/util.go
@@ -24,6 +24,7 @@ import (
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/client-go/dynamic"
@@ -70,8 +71,8 @@ func Allowed(a *admissionv1beta1.AdmissionRequest, pluralResourceName string, st
 	return false
 }
 
-func Unmarshal(a *admissionv1beta1.AdmissionRequest, object interface{}, status *admissionv1beta1.AdmissionResponse) error {
-	err := json.Unmarshal(a.Object.Raw, object)
+func Unmarshal(rawExt *runtime.RawExtension, object interface{}, status *admissionv1beta1.AdmissionResponse) error {
+	err := json.Unmarshal(rawExt.Raw, object)
 	if err != nil {
 		status.Allowed = false
 		status.Result = &metav1.Status{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes the KubeFedConfig `spec.scope` field immutable.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1058 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
