### PR TITLE
Add fatal check to deploy script for binary dependencies being installed

### DIFF
--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -18,9 +18,9 @@
 # current kubectl context.  It also registers the hosting cluster with
 # the control plane.
 #
-# This script depends on kubectl, kubebuilder and helm being installed
-# in the path.  These and other test binaries can be installed via the
-# download-binaries.sh script, which downloads to ./bin:
+# This script depends on kubectl and helm being installed in the path. These
+# and other test binaries can be installed via the download-binaries.sh script,
+# which downloads to ./bin:
 #
 #   $ ./scripts/download-binaries.sh
 #   $ export PATH=$(pwd)/bin:${PATH}
@@ -104,6 +104,16 @@ function kubefed-admission-webhook-ready() {
   [[ "${readyReplicas}" -ge "1" ]]
 }
 
+function check-command-installed() {
+  local cmdName="${1}"
+
+  command -v "${cmdName}" >/dev/null 2>&1 ||
+  {
+    echo "${cmdName} command not found. Please download dependencies using $(dirname ${BASH_SOURCE})/download-binaries.sh and install it in your PATH." >&2
+    exit 1
+  }
+}
+
 NS="${KUBEFED_NAMESPACE:-kube-federation-system}"
 IMAGE_NAME="${1:-}"
 NAMESPACED="${NAMESPACED:-}"
@@ -137,9 +147,12 @@ to ensure credentials are available for push:
   exit 2
 fi
 
-shift
 # Allow for no specific JOIN_CLUSTERS: they probably want to kubefedctl themselves.
+shift
 JOIN_CLUSTERS="${*-}"
+
+check-command-installed kubectl
+check-command-installed helm
 
 # Use DOCKER_PUSH= ./scripts/deploy-kubefed.sh <image> to skip docker
 # push on container image when not using latest image.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR ensures that the necessary binaries used by the script are installed before proceeding to perform any deployment actions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
