### PR TITLE
Update CI to test against kube v1.15.0

### DIFF
--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -144,7 +144,7 @@ echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
 CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y OVERWRITE_KUBECONFIG=y \
-    KIND_TAG="v1.14.2" ./scripts/create-clusters.sh
+    KIND_TAG="v1.15.0" ./scripts/create-clusters.sh
 
 # Initialize list of clusters to join
 join-cluster-list > /dev/null

--- a/test/e2e/ftccontroller.go
+++ b/test/e2e/ftccontroller.go
@@ -108,6 +108,8 @@ var _ = Describe("FTC controller", func() {
 			tl.Fatalf("Error updating target CRD version %q: %v", existingCrd.Spec.Version, err)
 		}
 
+		waitForTargetCrd(f.Logger(), f.KubeConfig(), targetAPIResource.Name, "v2")
+
 		By("Enabling federation of the CRD v2 to make target version of the FederatedTypeConfig updated")
 		needCleanup = false
 		typeConfig = enableResource(f, &targetAPIResource, "v2", needCleanup)
@@ -134,7 +136,7 @@ func enableResource(f framework.KubeFedFramework, targetAPIResource *metav1.APIR
 
 	resources, err := kfenable.GetResources(f.KubeConfig(), enableTypeDirective)
 	if err != nil {
-		tl.Fatalf("Error retrieving resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
+		tl.Fatalf("Error retrieving resources to enable federation of target type %q version %q: %v", targetAPIResource.Kind, version, err)
 	}
 	typeConfig := resources.TypeConfig
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kind` v0.4.0 now supports kube v1.15.0 so this updates the CI script to deploy and test against kube v1.15.0.

**Which issue(s) this PR fixes**:
Fixes #1079 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
