### PR TITLE
Fix panic when statusCollectoin is enabled

### DIFF
--- a/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
+++ b/pkg/apis/core/v1beta1/federatedtypeconfig_types.go
@@ -219,7 +219,9 @@ func (f *FederatedTypeConfig) GetStatusType() *metav1.APIResource {
 }
 
 func (f *FederatedTypeConfig) GetStatusEnabled() bool {
-	return f.Spec.StatusCollection != nil && *f.Spec.StatusCollection == StatusCollectionEnabled
+	return f.Spec.StatusCollection != nil &&
+		*f.Spec.StatusCollection == StatusCollectionEnabled &&
+		f.Name == "services"
 }
 
 // TODO(font): This method should be removed from the interface i.e. remove

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -95,6 +95,9 @@ func StartKubeFedStatusController(controllerConfig *util.ControllerConfig, stopC
 func newKubeFedStatusController(controllerConfig *util.ControllerConfig, typeConfig typeconfig.Interface) (*KubeFedStatusController, error) {
 	federatedAPIResource := typeConfig.GetFederatedType()
 	statusAPIResource := typeConfig.GetStatusType()
+	if statusAPIResource == nil {
+		return nil, errors.Errorf("Status collection is not supported for %q", federatedAPIResource.Kind)
+	}
 	userAgent := fmt.Sprintf("%s-controller", strings.ToLower(statusAPIResource.Kind))
 	client := genericclient.NewForConfigOrDieWithUserAgent(controllerConfig.KubeConfig, userAgent)
 


### PR DESCRIPTION
Set default value for statusType

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When statusType is not set, return targetType.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/kubefed/issues/1069

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
