### PR TITLE
kubefedctl: Set host cluster context to current context if empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+-  [#1076](https://github.com/kubernetes-sigs/kubefed/pull/1076)
+   All `kubefedctl` commands now default `--host-cluster-context` to the
+   current context in log messages.
 -  [#1086](https://github.com/kubernetes-sigs/kubefed/pull/1086)
    `kubefedctl federate` now removes all metadata fields except labels
    from the template of federated resources created from a

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -166,6 +166,10 @@ func (j *joinFederation) Complete(args []string) error {
 // Run is the implementation of the `join` command.
 func (j *joinFederation) Run(cmdOut io.Writer, config util.FedConfig) error {
 	hostClientConfig := config.GetClientConfig(j.HostClusterContext, j.Kubeconfig)
+	if err := j.SetHostClusterContextFromConfig(hostClientConfig); err != nil {
+		return err
+	}
+
 	hostConfig, err := hostClientConfig.ClientConfig()
 	if err != nil {
 		// TODO(font): Return new error with this same text so it can be output
@@ -183,16 +187,6 @@ func (j *joinFederation) Run(cmdOut io.Writer, config util.FedConfig) error {
 	if err != nil {
 		klog.V(2).Infof("Failed to get joining cluster config: %v", err)
 		return err
-	}
-
-	// Set HostClusterContext as current context in kube config if it is not set
-	if j.HostClusterContext == "" {
-		rawConfig, err := hostClientConfig.RawConfig()
-		if err != nil {
-			klog.V(2).Infof("Failed to get current context in host client config")
-			return err
-		}
-		j.HostClusterContext = rawConfig.CurrentContext
 	}
 
 	hostClusterName := j.HostClusterContext

--- a/pkg/kubefedctl/orphaning/orphaning.go
+++ b/pkg/kubefedctl/orphaning/orphaning.go
@@ -100,7 +100,11 @@ func (o *orphanResource) Complete(args []string, config util.FedConfig) error {
 
 // Returns a Federated Resources Interface
 func (o *orphanResource) GetResourceClient(config util.FedConfig, cmdOut io.Writer) (dynamic.ResourceInterface, error) {
-	hostConfig, err := config.HostConfig(o.HostClusterContext, o.Kubeconfig)
+	hostClientConfig := config.GetClientConfig(o.HostClusterContext, o.Kubeconfig)
+	if err := o.SetHostClusterContextFromConfig(hostClientConfig); err != nil {
+		return nil, err
+	}
+	hostConfig, err := hostClientConfig.ClientConfig()
 	if err != nil {
 		return nil, errors.Wrapf(err, "Unable to load configuration for cluster context %q in kubeconfig %q.`",
 			o.HostClusterContext, o.Kubeconfig)

--- a/pkg/kubefedctl/util/util.go
+++ b/pkg/kubefedctl/util/util.go
@@ -128,10 +128,16 @@ func IsFederatedAPIResource(kind, group string) bool {
 
 // GetNamespace returns namespace of the current context
 func GetNamespace(hostClusterContext string, kubeconfig string, config FedConfig) (string, error) {
-	ns, _, err := config.GetClientConfig(hostClusterContext, kubeconfig).Namespace()
+	clientConfig := config.GetClientConfig(hostClusterContext, kubeconfig)
+	currentContext, err := options.CurrentContext(clientConfig)
+	if err != nil {
+		return "", err
+	}
+
+	ns, _, err := clientConfig.Namespace()
 	if err != nil {
 		return "", errors.Wrapf(err, "Failed to get ClientConfig for host cluster context %q and kubeconfig %q",
-			hostClusterContext, kubeconfig)
+			currentContext, kubeconfig)
 	}
 
 	if len(ns) == 0 {


### PR DESCRIPTION
For any invocation of `kubefedctl` that does not specify a value for `--host-cluster-context`, the current config context will be
used. However, other usage of the `HostClusterContext` variable requires explicitly looking up the name of the current context to avoid using an empty string.

#1065 fixed the `join` command to lookup the current context. This change ensures the same lookup is performed for all `kubefedctl` commands.