### PR TITLE
Require the spec field in generated federated types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Unreleased
+-  [#1079](https://github.com/kubernetes-sigs/kubefed/issues/1079) The
+   spec field is now required in generated federated types. For types
+   generated previously, a check has been added so that a missing spec
+   field does not cause a nil pointer exception.
 
 # v0.1.0-rc5
 -  [#1058](https://github.com/kubernetes-sigs/kubefed/issues/1058)

--- a/charts/kubefed/templates/crds.yaml
+++ b/charts/kubefed/templates/crds.yaml
@@ -123,6 +123,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -250,6 +252,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -379,6 +383,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -506,6 +512,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -631,6 +639,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -758,6 +768,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -887,6 +899,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1012,6 +1026,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1139,6 +1155,8 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1266,5 +1284,7 @@ spec:
                 type: object
               type: array
           type: object
+      required:
+      - spec
   version: v1beta1
 {{ end }}

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -272,6 +272,9 @@ func GetOverrideHash(rawObj *unstructured.Unstructured) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "Error retrieving overrides")
 	}
+	if override.Spec == nil {
+		return "", nil
+	}
 	// Only hash the overrides
 	obj := &unstructured.Unstructured{
 		Object: map[string]interface{}{

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -243,6 +243,14 @@ func ValidationSchema(specProps v1beta1.JSONSchemaProps) *v1beta1.CustomResource
 					},
 				},
 			},
+			// Require a spec (even if empty) as an aid to users
+			// manually creating federated configmaps or
+			// secrets. These target types do not include a spec,
+			// and the absence of the spec in a federated
+			// equivalent could indicate a malformed resource.
+			Required: []string{
+				"spec",
+			},
 		},
 	}
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -259,14 +259,14 @@ func (f *frameworkWrapper) EnsureTestFederatedNamespace(allClusters bool) *unstr
 	// Othewise create it.
 	obj.SetName(namespace)
 	obj.SetNamespace(namespace)
+	spec := map[string]interface{}{}
 	if allClusters {
 		// An empty cluster selector field selects all clusters
-		obj.Object[util.SpecField] = map[string]interface{}{
-			util.PlacementField: map[string]interface{}{
-				util.ClusterSelectorField: map[string]interface{}{},
-			},
+		spec[util.PlacementField] = map[string]interface{}{
+			util.ClusterSelectorField: map[string]interface{}{},
 		}
 	}
+	obj.Object[util.SpecField] = spec
 
 	err = client.Create(context.Background(), obj)
 	if err != nil {


### PR DESCRIPTION
A missing spec field in a federated resource is a potential indication of a malformed resource. For existing resources, a check has been added for a missing spec field before attempting to compute a hash of overrides to prevent a nil pointer exception.

Fixes #1079 