### PR TITLE
Remove all metadata fields but labels from targets of kf federate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
+-  [#1086](https://github.com/kubernetes-sigs/kubefed/pull/1086)
+   `kubefedctl federate` now removes all metadata fields except labels
+   from the template of federated resources created from a
+   non-federated resource. Previously `metadata.annotations` and
+   `metadata.finalizers` were not removed which could result in
+   propagation errors.
 -  [#1079](https://github.com/kubernetes-sigs/kubefed/issues/1079) The
    spec field is now required in generated federated types. For types
    generated previously, a check has been added so that a missing spec

--- a/pkg/kubefedctl/federate/util.go
+++ b/pkg/kubefedctl/federate/util.go
@@ -38,19 +38,27 @@ import (
 	"sigs.k8s.io/kubefed/pkg/kubefedctl/util"
 )
 
-var systemMetadataFields = []string{"selfLink", "uid", "resourceVersion", "generation", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds"}
-
-func RemoveUnwantedFields(resource *unstructured.Unstructured) {
-	for _, field := range systemMetadataFields {
-		unstructured.RemoveNestedField(resource.Object, "metadata", field)
-		// For resources with pod template subresource (jobs, deployments, replicasets)
-		unstructured.RemoveNestedField(resource.Object, "spec", "template", "metadata", field)
-	}
-	unstructured.RemoveNestedField(resource.Object, "metadata", "name")
-	unstructured.RemoveNestedField(resource.Object, "metadata", "namespace")
+func RemoveUnwantedFields(resource *unstructured.Unstructured) error {
 	unstructured.RemoveNestedField(resource.Object, "apiVersion")
 	unstructured.RemoveNestedField(resource.Object, "kind")
 	unstructured.RemoveNestedField(resource.Object, "status")
+
+	// All metadata fields save labels should be cleared. Other
+	// metadata fields will be set by the system on creation or
+	// subsequently by controllers.
+	labels, _, err := unstructured.NestedMap(resource.Object, "metadata", "labels")
+	if err != nil {
+		return errors.Wrap(err, "Failed to retrieve metadata.labels")
+	}
+	unstructured.RemoveNestedField(resource.Object, "metadata")
+	if len(labels) > 0 {
+		err := unstructured.SetNestedMap(resource.Object, labels, "metadata", "labels")
+		if err != nil {
+			return errors.Wrap(err, "Failed to set metadata.labels")
+		}
+	}
+
+	return nil
 }
 
 func SetBasicMetaFields(resource *unstructured.Unstructured, apiResource metav1.APIResource, name, namespace, generateName string) {

--- a/test/e2e/federate.go
+++ b/test/e2e/federate.go
@@ -264,8 +264,12 @@ func validateTemplateEquality(tl common.TestLogger, fedResource, targetResource 
 
 	expectedResource := &unstructured.Unstructured{}
 	expectedResource.Object = templateMap.(map[string]interface{})
-	federate.RemoveUnwantedFields(expectedResource)
-	federate.RemoveUnwantedFields(targetResource)
+	if err := federate.RemoveUnwantedFields(expectedResource); err != nil {
+		tl.Fatalf("Failed to remove unwanted fields from expected resource: %v", err)
+	}
+	if err := federate.RemoveUnwantedFields(targetResource); err != nil {
+		tl.Fatalf("Failed to remove unwanted fields from target resource: %v", err)
+	}
 	if kind == util.NamespaceKind {
 		unstructured.RemoveNestedField(targetResource.Object, "spec", "finalizers")
 	}


### PR DESCRIPTION
Previously `kubefedctl federate` removed a subset of metadata fields from the resource targeted for conversion to a federated resource. It wasn't removing `metadata.annotations` or `metadata.finalizers` despite those fields not being supported for propagation. This change ensures that all metadata fields are removed except labels to ensure that fields set by the local cluster and its controllers are not included in the template of the new federated resource.