### PR TITLE
1087. Replica count of federated deployment is not updated by RSP plugin

### DIFF
--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -213,9 +213,9 @@ func updateOverridesMap(overridesMap util.OverridesMap, replicasMap map[string]i
 	// Add/update replicas override for clusters that are scheduled
 	for clusterName, replicas := range replicasMap {
 		replicasOverrideFound := false
-		for _, overrideItem := range overridesMap[clusterName] {
+		for idx, overrideItem := range overridesMap[clusterName] {
 			if overrideItem.Path == replicasPath {
-				overrideItem.Value = replicas
+				overridesMap[clusterName][idx].Value = replicas
 				replicasOverrideFound = true
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
ReplicaSchedulingPreference's plugin doesn't updates FederatedDeployment with latest overrides of replica count.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1087 

**Special notes for your reviewer**:
