### PR TITLE
Revert "Add image build for darwin"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,8 @@ vet:
 fmt:
 	$(shell ./hack/update-gofmt.sh)
 
-container: $(HYPERFED_TARGET)-$(HOST_PLATFORM)
-	cp -f $(HYPERFED_TARGET)-$(HOST_PLATFORM) images/kubefed/hyperfed
+container: $(HYPERFED_TARGET)-linux-$(HOST_ARCH)
+	cp -f $(HYPERFED_TARGET)-linux-$(HOST_ARCH) images/kubefed/hyperfed
 	$(DOCKER) build images/kubefed -t $(IMAGE_NAME)
 	rm -f images/kubefed/hyperfed
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubefed#1094

There's a reason we don't support building a container with a darwin binary. Containers are linux-only, so a kubefed image with a darwin binary is by definition a broken container.

cc: @gyliu513 @xunpan @hougangliu 