### PR TITLE
Fix logging statements: duration logging statement should be wrapped …

### DIFF
--- a/pkg/controller/ingressdns/controller.go
+++ b/pkg/controller/ingressdns/controller.go
@@ -209,7 +209,9 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 
 	klog.V(2).Infof("Starting to reconcile IngressDNS resource: %v", key)
 	startTime := time.Now()
-	defer klog.V(2).Infof("Finished reconciling IngressDNS resource %v (duration: %v)", key, time.Since(startTime))
+	defer func() {
+		klog.V(2).Infof("Finished reconciling IngressDNS resource %v (duration: %v)", key, time.Since(startTime))
+	}()
 
 	cachedIngressDNSObj, exist, err := c.ingressDNSStore.GetByKey(key)
 	if err != nil {

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -203,7 +203,9 @@ func (s *SchedulingPreferenceController) reconcile(qualifiedName util.QualifiedN
 
 	klog.V(4).Infof("Starting to reconcile %s controller triggered key named %v", kind, key)
 	startTime := time.Now()
-	defer klog.V(4).Infof("Finished reconciling %s controller triggered key named %v (duration: %v)", kind, key, time.Since(startTime))
+	defer func() {
+		klog.V(4).Infof("Finished reconciling %s controller triggered key named %v (duration: %v)", kind, key, time.Since(startTime))
+	}()
 
 	obj, err := s.objFromCache(s.store, kind, key)
 	if err != nil {

--- a/pkg/controller/servicedns/controller.go
+++ b/pkg/controller/servicedns/controller.go
@@ -265,7 +265,9 @@ func (c *Controller) reconcile(qualifiedName util.QualifiedName) util.Reconcilia
 
 	klog.V(4).Infof("Starting to reconcile ServiceDNS resource: %v", key)
 	startTime := time.Now()
-	defer klog.V(4).Infof("Finished reconciling ServiceDNS resource %v (duration: %v)", key, time.Since(startTime))
+	defer func() {
+		klog.V(4).Infof("Finished reconciling ServiceDNS resource %v (duration: %v)", key, time.Since(startTime))
+	}()
 
 	cachedObj, exist, err := c.serviceDNSStore.GetByKey(key)
 	if err != nil {

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -241,7 +241,9 @@ func (s *KubeFedStatusController) reconcile(qualifiedName util.QualifiedName) ut
 
 	klog.V(4).Infof("Starting to reconcile %v %v", statusKind, key)
 	startTime := time.Now()
-	defer klog.V(4).Infof("Finished reconciling %v %v (duration: %v)", statusKind, key, time.Since(startTime))
+	defer func() {
+		klog.V(4).Infof("Finished reconciling %v %v (duration: %v)", statusKind, key, time.Since(startTime))
+	}()
 
 	fedObject, err := s.objFromCache(s.federatedStore, federatedKind, key)
 	if err != nil {

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -267,7 +267,9 @@ func (s *KubeFedSyncController) reconcile(qualifiedName util.QualifiedName) util
 
 	klog.V(4).Infof("Starting to reconcile %s %q", kind, key)
 	startTime := time.Now()
-	defer klog.V(4).Infof("Finished reconciling %s %q (duration: %v)", kind, key, time.Since(startTime))
+	defer func() {
+		klog.V(4).Infof("Finished reconciling %s %q (duration: %v)", kind, key, time.Since(startTime))
+	}()
 
 	if fedResource.Object().GetDeletionTimestamp() != nil {
 		klog.V(3).Infof("Handling deletion of %s %q", kind, key)


### PR DESCRIPTION
Found some error prone logging statements like below:
https://github.com/kubernetes-sigs/kubefed/blob/01b9e5c1a4f1144c6a63c182b0f760eec30db57e/pkg/controller/ingressdns/controller.go#L210-L212
The 'time.Since(...)' in the defferred statement will be immediately evaluated instead of being evaluated when this statement is executed.

**What this PR does / why we need it:**
Wrapping the logging statement in a function to solve this issue.
