### PR TITLE
Skip writing propagated version to the API when unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+-  [#1098](https://github.com/kubernetes-sigs/kubefed/pull/1098)
+   Propagated version is now only updated when changed.
 -  [#1087](https://github.com/kubernetes-sigs/kubefed/issues/1087)
    The ReplicaScheduling controller now correctly updates existing
    overrides of `/spec/replicas`. Previously the controller was able


### PR DESCRIPTION
The existing check for unchanged propagated version status was still resulting in an unnecessary API update.