### PR TITLE
Minimize updates to propagation status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased
+-  [#1098](https://github.com/kubernetes-sigs/kubefed/pull/1098)
+   Propagated version is now only updated when changed.
 -  [#1087](https://github.com/kubernetes-sigs/kubefed/issues/1087)
    The ReplicaScheduling controller now correctly updates existing
    overrides of `/spec/replicas`. Previously the controller was able

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+-  [#1099](https://github.com/kubernetes-sigs/kubefed/pull/1099)
+   Updates to propagation status are now only made in response to
+   propagation to member clusters or errors in propagation. Previously
+   propagation status was updated every time a federated resource was
+   reconciled which could result in unnecessary resource consumption.
 -  [#1098](https://github.com/kubernetes-sigs/kubefed/pull/1098)
    Propagated version is now only updated when changed.
 -  [#1087](https://github.com/kubernetes-sigs/kubefed/issues/1087)

--- a/charts/kubefed/templates/crds.yaml
+++ b/charts/kubefed/templates/crds.yaml
@@ -105,10 +105,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -234,10 +234,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -365,10 +365,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -494,10 +494,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -621,10 +621,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -750,10 +750,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -881,10 +881,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -1008,10 +1008,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -1137,10 +1137,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:
@@ -1266,10 +1266,10 @@ spec:
             conditions:
               items:
                 properties:
-                  lastProbeTime:
+                  lastTransitionTime:
                     format: date-time
                     type: string
-                  lastTransitionTime:
+                  lastUpdateTime:
                     format: date-time
                     type: string
                   reason:

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -376,11 +376,13 @@ status:
   conditions:
   - type: Propagation
     status: True
-    lastProbeTime: "2019-05-08T01:23:20Z"
     lastTransitionTime: "2019-05-08T01:23:20Z"
+    lastUpdateTime: "2019-05-08T01:23:20Z"
   # The namespace 'myns' has been verified to exist in the
-  # following clusters as of the lastProbeTime recorded
-  # in the 'Propagation' condition.
+  # following clusters as of the lastUpdateTime recorded
+  # in the 'Propagation' condition. Since that time, no
+  # change has been detected to this resource or the
+  # resources it manages.
   clusters:
   - name: cluster1
   - name: cluster2
@@ -435,8 +437,8 @@ status:
   - type: Propagation
     status: False
     reason: CheckClusters
-    lastProbeTime: "2019-05-08T01:23:20Z"
     lastTransitionTime: "2019-05-08T01:23:20Z"
+    lastUpdateTime: "2019-05-08T01:23:20Z"
   clusters:
   - name: cluster1
   - name: cluster2

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -272,10 +272,8 @@ func (s *KubeFedSyncController) reconcile(qualifiedName util.QualifiedName) util
 	}()
 
 	if fedResource.Object().GetDeletionTimestamp() != nil {
-		klog.V(3).Infof("Handling deletion of %s %q", kind, key)
 		return s.ensureDeletion(fedResource)
 	}
-	klog.V(3).Infof("Ensuring finalizer exists on %s %q", kind, key)
 	err = s.ensureFinalizer(fedResource)
 	if err != nil {
 		fedResource.RecordError("EnsureFinalizerError", errors.Wrap(err, "Failed to ensure finalizer"))
@@ -302,7 +300,7 @@ func (s *KubeFedSyncController) syncToClusters(fedResource FederatedResource) ut
 
 	kind := fedResource.TargetKind()
 	key := fedResource.TargetName().String()
-	klog.V(4).Infof("Syncing %s %q in underlying clusters, selected clusters are: %s", kind, key, selectedClusterNames)
+	klog.V(4).Infof("Ensuring %s %q in clusters: %s", kind, key, strings.Join(selectedClusterNames.List(), ","))
 
 	dispatcher := dispatch.NewManagedDispatcher(s.informer.GetClientForCluster, fedResource, s.skipAdoptingResources)
 

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"testing"
+
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
+	testCases := map[string]struct {
+		reason           AggregateReason
+		statusMap        PropagationStatusMap
+		resourcesUpdated bool
+		expectedChanged  bool
+	}{
+		"No change in clusters indicates unchanged": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+		},
+		"No change in clusters with update indicates changed": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourcesUpdated: true,
+			expectedChanged:  true,
+		},
+		"Change in clusters indicates changed": {
+			expectedChanged: true,
+		},
+		"Transition indicates changed": {
+			reason:          NamespaceNotFederated,
+			expectedChanged: true,
+		},
+	}
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			propStatus := &GenericPropagationStatus{
+				Clusters: []GenericClusterStatus{
+					{
+						Name: "cluster1",
+					},
+				},
+				Conditions: []*GenericCondition{
+					{
+						Type:   PropagationConditionType,
+						Status: apiv1.ConditionTrue,
+					},
+				},
+			}
+			collectedStatus := CollectedPropagationStatus{
+				StatusMap:        tc.statusMap,
+				ResourcesUpdated: tc.resourcesUpdated,
+			}
+			changed := propStatus.update(tc.reason, collectedStatus)
+			if tc.expectedChanged != changed {
+				t.Fatalf("Expected changed to be %v, got %v", tc.expectedChanged, changed)
+			}
+		})
+	}
+}

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -61,13 +61,6 @@ const (
 	PathField             = "path"
 	ValueField            = "value"
 
-	// Propagation status fields
-	ConditionsField         = "conditions"
-	TypeField               = "type"
-	ReasonField             = "reason"
-	LastProbeTimeField      = "lastProbeTime"
-	LastTransitionTimeField = "lastTransitionTime"
-
 	// Cluster reference
 	ClustersField = "clusters"
 	NameField     = "name"

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -205,7 +205,7 @@ func ValidationSchema(specProps v1beta1.JSONSchemaProps) *v1beta1.CustomResource
 										"reason": {
 											Type: "string",
 										},
-										"lastProbeTime": {
+										"lastUpdateTime": {
 											Format: "date-time",
 											Type:   "string",
 										},


### PR DESCRIPTION
Each status update to a federated resource results in a subsequent reconcile. Previously this was creating an endless cycle of reconciliation even when there were no propagation changes since the `lastProbeTime` timestamp was always changed even if nothing else did. This induced unnecessary overhead in the controller manager, kube apiserver, and etcd.

Kubernetes saw a similar problem with `lastProbeTime` on pods: https://github.com/kubernetes/kubernetes/issues/14393

This PR limits propagation status updates to when the status has actually changed - either due to a propagation error or changes being propagated to member clusters. This suggested replacing `lastProbeTime` with `lastUpdateTime`.