### PR TITLE
controller: process label updates to kubefedcluster resources

### DIFF
--- a/pkg/controller/kubefedcluster/controller.go
+++ b/pkg/controller/kubefedcluster/controller.go
@@ -144,7 +144,10 @@ func newClusterController(config *util.ControllerConfig, clusterHealthCheckConfi
 				cluster := newObj.(*fedv1b1.KubeFedCluster)
 				cc.mu.Lock()
 				clusterData, ok := cc.clusterDataMap[cluster.Name]
-				if ok && !equality.Semantic.DeepEqual(clusterData.cachedObj.Spec, cluster.Spec) {
+
+				if ok && !equality.Semantic.DeepEqual(clusterData.cachedObj.Spec, cluster.Spec) &&
+					!equality.Semantic.DeepEqual(clusterData.cachedObj.ObjectMeta.Annotations, cluster.ObjectMeta.Annotations) &&
+					!equality.Semantic.DeepEqual(clusterData.cachedObj.ObjectMeta.Labels, cluster.ObjectMeta.Labels) {
 					clusterChanged = true
 				}
 				cc.mu.Unlock()

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -221,7 +221,7 @@ func NewFederatedInformer(
 					klog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
 					return
 				}
-				if IsClusterReady(&oldCluster.Status) != IsClusterReady(&curCluster.Status) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {
+				if IsClusterReady(&oldCluster.Status) != IsClusterReady(&curCluster.Status) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Labels, curCluster.ObjectMeta.Labels) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {
 					var data []interface{}
 					if clusterLifecycle.ClusterUnavailable != nil {
 						data = getClusterData(oldCluster.Name)


### PR DESCRIPTION
This PR addresses label update handling on KubeFedCluster resources.  Adding/removing labels was not triggering federated resource sync.