### PR TITLE
kubefedctl federate: ensure that --dry-run avoids mutating api state

### DIFF
--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -442,7 +442,7 @@ func CreateResources(cmdOut io.Writer, hostConfig *rest.Config, artifactsList []
 			if err != nil {
 				return err
 			}
-			err = enable.CreateResources(cmdOut, hostConfig, typeResources, namespace)
+			err = enable.CreateResources(cmdOut, hostConfig, typeResources, namespace, dryRun)
 			if err != nil {
 				return err
 			}

--- a/test/e2e/crd.go
+++ b/test/e2e/crd.go
@@ -148,7 +148,7 @@ func validateCrdCrud(f framework.KubeFedFramework, targetCrdKind string, namespa
 	}
 	typeConfig := resources.TypeConfig
 
-	err = kfenable.CreateResources(nil, hostConfig, resources, f.KubeFedSystemNamespace())
+	err = kfenable.CreateResources(nil, hostConfig, resources, f.KubeFedSystemNamespace(), false)
 	if err != nil {
 		tl.Fatalf("Error creating resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}

--- a/test/e2e/ftccontroller.go
+++ b/test/e2e/ftccontroller.go
@@ -140,7 +140,7 @@ func enableResource(f framework.KubeFedFramework, targetAPIResource *metav1.APIR
 	}
 	typeConfig := resources.TypeConfig
 
-	err = kfenable.CreateResources(nil, f.KubeConfig(), resources, f.KubeFedSystemNamespace())
+	err = kfenable.CreateResources(nil, f.KubeConfig(), resources, f.KubeFedSystemNamespace(), false)
 	if err != nil {
 		tl.Fatalf("Error creating resources to enable federation of target type %q: %v", targetAPIResource.Kind, err)
 	}

--- a/test/e2e/schedulermanager.go
+++ b/test/e2e/schedulermanager.go
@@ -150,7 +150,7 @@ func enableTypeConfigResource(name, namespace string, config *restclient.Config,
 		}
 
 		if enableTypeDirective.Name == name {
-			err = kfenable.CreateResources(nil, config, resources, namespace)
+			err = kfenable.CreateResources(nil, config, resources, namespace, false)
 			if err != nil {
 				tl.Fatalf("Error creating resources for EnableTypeDirective %q: %v", enableTypeDirective.Name, err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR propagates the dry run flag to the `enable type` functionality
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #1102

**Special notes for your reviewer**:
