### PR TITLE
Change shorthand --enable-type flag to avoid typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+-  [#1121](https://github.com/kubernetes-sigs/kubefed/pull/1121) Update
+   `kubefedctl federate` shorthand option for `--enable-type` to `-t` instead
+   of `-e` to avoid confusing error message when only one dash is accidentally
+   used e.g. `-enable-type`, resulting in a valid parsing of flags but
+   erroneous use of the option.
 
 # v0.1.0-rc6
 -  [#1099](https://github.com/kubernetes-sigs/kubefed/pull/1099)

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -90,7 +90,7 @@ type federateResource struct {
 func (j *federateResource) Bind(flags *pflag.FlagSet) {
 	flags.StringVarP(&j.resourceNamespace, "namespace", "n", "", "The namespace of the resource to federate.")
 	flags.StringVarP(&j.output, "output", "o", "", "If provided, the resource that would be created in the API by the command is instead output to stdout in the provided format.  Valid format is ['yaml'].")
-	flags.BoolVarP(&j.enableType, "enable-type", "e", false, "If true, attempt to enable federation of the API type of the resource before creating the federated resource.")
+	flags.BoolVarP(&j.enableType, "enable-type", "t", false, "If true, attempt to enable federation of the API type of the resource before creating the federated resource.")
 	flags.BoolVarP(&j.federateContents, "contents", "c", false, "Applicable only to namespaces. If provided, the command will federate all resources within the namespace after federating the namespace.")
 	flags.StringVarP(&j.filename, "filename", "f", "", "If specified, the provided yaml file will be used as the input for target resources to federate. This mode will only emit federated resource yaml to standard output. Other flag options if provided will be ignored.")
 	flags.StringSliceVarP(&j.skipAPIResourceNames, "skip-api-resources", "s", []string{}, "Comma separated names of the api resources to skip when federating contents in a namespace. Name could be short name "+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The `--enable-type` long option can be accidentally typed with only 1 `-` as in `-enable-type` resulting in the following error:

```bash
$ kubefedctl federate secret kubefed -enable-type
F0809 15:24:48.160303   17400 federate.go:150] Error: Error retrieving target Secret "able-type/kubefed": secrets "kubefed" not found
```

The error occurs because combined shorthand options as in `-en` are valid. If a shorthand option takes an argument, as in `-n`, it must be the last argument, so it interprets the rest of the command `able-type` as the namespace argument. This can be confusing and is only a special case because `e` and `n` are both shorthand flags while their combined use spells out the long form of an option.

This fixes that by changing the shorthand flag for `--enable-type` to `-t` instead of `-e`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
