### PR TITLE
Update to use go 1.12.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 # The version used here should match the BUILD_IMAGE variable in the
 # Makefile.
 go:
-  - "1.12.5"
+  - "1.12.9"
 
 # Enable building in Travis using forked repos.
 go_import_path: sigs.k8s.io/kubefed

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 BUILDMNT = /go/src/$(GOTARGET)
 # The version here should match the version of go configured in
 # .travis.yml
-BUILD_IMAGE ?= golang:1.12.5
+BUILD_IMAGE ?= golang:1.12.9
 
 HYPERFED_TARGET = bin/hyperfed
 CONTROLLER_TARGET = bin/controller-manager

--- a/pkg/apis/core/v1beta1/validation/validation_test.go
+++ b/pkg/apis/core/v1beta1/validation/validation_test.go
@@ -462,11 +462,11 @@ func TestValidateAPIEndpoint(t *testing.T) {
 		},
 		{
 			"example.com:port80",
-			`apiEndpoint: Invalid value: "port80": error converting port to integer`,
+			`apiEndpoint: Invalid value: "example.com:port80": parse https://example.com:port80: invalid port ":port80" after host`,
 		},
 		{
 			"example.com:-80",
-			"apiEndpoint: Invalid value: -80: must be between 1 and 65535, inclusive",
+			`apiEndpoint: Invalid value: "example.com:-80": parse https://example.com:-80: invalid port ":-80" after host`,
 		},
 		{
 			"example.com:0",


### PR DESCRIPTION
This update includes changes to handle a backported CVE fix for CVE-2019-14809 [1] that was introduced in go 1.12.8 [2]. That fix results in the `url.Parse` API making sure port is only decimals, so the validation code will now catch the error earlier instead of later in the `Atoi` conversion.

[1] https://github.com/golang/go/commit/3226f2d492963d361af9dfc6714ef141ba606713
[2] https://github.com/golang/go/issues/33633
