### PR TITLE
add resource "secrets"  for kubefed-role

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
@@ -51,6 +51,7 @@ rules:
   - ""
   resources:
   - namespaces
+  - secrets
   verbs:
   - get
   - watch


### PR DESCRIPTION
currently kubefed-role  does not include resource "secrets"  in API group "" so that it will cause the "system:serviceaccount:kube-federation-system:kubefed-controller" cannot get resource "secrets".

