### PR TITLE
Ensure validation schema of federated types is openapi compatible

### DIFF
--- a/charts/kubefed/templates/crds.yaml
+++ b/charts/kubefed/templates/crds.yaml
@@ -39,12 +39,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -128,6 +123,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -171,12 +167,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -260,6 +251,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -303,12 +295,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -394,6 +381,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -437,12 +425,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -526,6 +509,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -567,12 +551,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -656,6 +635,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -699,12 +679,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -788,6 +763,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -831,12 +807,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -922,6 +893,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -963,12 +935,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1052,6 +1019,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1095,12 +1063,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1184,6 +1147,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1227,12 +1191,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1316,5 +1275,6 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 {{ end }}

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -23,6 +23,7 @@ import (
 )
 
 func federatedTypeValidationSchema(templateSchema map[string]v1beta1.JSONSchemaProps) *v1beta1.CustomResourceValidation {
+	preserveUnknownFields := true
 	schema := ValidationSchema(v1beta1.JSONSchemaProps{
 		Type: "object",
 		Properties: map[string]v1beta1.JSONSchemaProps{
@@ -114,28 +115,12 @@ func federatedTypeValidationSchema(templateSchema map[string]v1beta1.JSONSchemaP
 											"path": {
 												Type: "string",
 											},
+											// Supporting the override of an arbitrary field
+											// precludes up-front validation.  Errors in
+											// the definition of override values will need to
+											// be caught during propagation.
 											"value": {
-												// Supporting the override of an arbitrary field
-												// precludes up-front validation.  Errors in
-												// the definition of override values will need to
-												// be caught during propagation.
-												AnyOf: []v1beta1.JSONSchemaProps{
-													{
-														Type: "string",
-													},
-													{
-														Type: "integer",
-													},
-													{
-														Type: "boolean",
-													},
-													{
-														Type: "object",
-													},
-													{
-														Type: "array",
-													},
-												},
+												XPreserveUnknownFields: &preserveUnknownFields,
 											},
 										},
 										Required: []string{
@@ -255,6 +240,7 @@ func ValidationSchema(specProps v1beta1.JSONSchemaProps) *v1beta1.CustomResource
 			Required: []string{
 				"spec",
 			},
+			Type: "object",
 		},
 	}
 }


### PR DESCRIPTION
Previously the validation schema of federated types was failing structural validation, which is a precondition for being published in the API server's OpenAPI schema (consumed by `kubectl explain` and others). This change ensures that federated types will have validation schema compatible with being published as OpenAPI schema.

Partial fix for #1141 