### PR TITLE
#1083: use unstructured runtime.Object for more detailed reflector logging

### DIFF
--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -133,10 +133,9 @@ func newKubeFedStatusController(controllerConfig *util.ControllerConfig, typeCon
 
 	targetNamespace := controllerConfig.TargetNamespace
 
-	s.federatedStore, s.federatedController = util.NewResourceInformer(federatedTypeClient, targetNamespace, enqueueObj)
-	s.statusStore, s.statusController = util.NewResourceInformer(statusClient, targetNamespace, enqueueObj)
-
 	targetAPIResource := typeConfig.GetTargetType()
+	s.federatedStore, s.federatedController = util.NewResourceInformer(federatedTypeClient, targetNamespace, &targetAPIResource, enqueueObj)
+	s.statusStore, s.statusController = util.NewResourceInformer(statusClient, targetNamespace, statusAPIResource, enqueueObj)
 
 	// Federated informer for resources in member clusters
 	s.informer, err = util.NewFederatedInformer(

--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -95,7 +95,7 @@ func NewFederatedResourceAccessor(
 	if err != nil {
 		return nil, err
 	}
-	a.federatedStore, a.federatedController = util.NewResourceInformer(federatedTypeClient, targetNamespace, enqueueObj)
+	a.federatedStore, a.federatedController = util.NewResourceInformer(federatedTypeClient, targetNamespace, &federatedTypeAPIResource, enqueueObj)
 
 	if a.targetIsNamespace {
 		// Initialize an informer for namespaces.  The namespace
@@ -106,7 +106,7 @@ func NewFederatedResourceAccessor(
 		if err != nil {
 			return nil, err
 		}
-		a.namespaceStore, a.namespaceController = util.NewResourceInformer(namespaceTypeClient, targetNamespace, enqueueObj)
+		a.namespaceStore, a.namespaceController = util.NewResourceInformer(namespaceTypeClient, targetNamespace, &namespaceAPIResource, enqueueObj)
 	}
 
 	if typeConfig.GetNamespaced() {
@@ -133,7 +133,7 @@ func NewFederatedResourceAccessor(
 		if err != nil {
 			return nil, err
 		}
-		a.fedNamespaceStore, a.fedNamespaceController = util.NewResourceInformer(fedNamespaceClient, targetNamespace, fedNamespaceEnqueue)
+		a.fedNamespaceStore, a.fedNamespaceController = util.NewResourceInformer(fedNamespaceClient, targetNamespace, fedNamespaceAPIResource, fedNamespaceEnqueue)
 	}
 
 	a.versionManager = version.NewVersionManager(

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -147,7 +147,7 @@ func NewFederatedInformer(
 			return nil, nil, err
 		}
 		targetNamespace := NamespaceForCluster(cluster.Name, config.TargetNamespace)
-		store, controller := NewManagedResourceInformer(resourceClient, targetNamespace, triggerFunc)
+		store, controller := NewManagedResourceInformer(resourceClient, targetNamespace, apiResource, triggerFunc)
 		return store, controller, nil
 	}
 

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -82,7 +82,7 @@ func NewPlugin(controllerConfig *util.ControllerConfig, eventHandlers SchedulerE
 	if err != nil {
 		return nil, err
 	}
-	p.federatedStore, p.federatedController = util.NewResourceInformer(p.federatedTypeClient, targetNamespace, kubeFedEventHandler)
+	p.federatedStore, p.federatedController = util.NewResourceInformer(p.federatedTypeClient, targetNamespace, &federatedTypeAPIResource, kubeFedEventHandler)
 
 	return p, nil
 }


### PR DESCRIPTION
use unstructured runtime.Object with the apiResource info when registering informers (needs backend change in client-go to log the gvk of the unstructured object)

Fixes #1083 

**Special notes for reviewer**:
Detailed logging will be dependent on merge of below PR to Kubernetes client-go:
https://github.com/kubernetes/kubernetes/pull/82388