### PR TITLE
Relax KubeFedCluster APIEndpoint validation

### DIFF
--- a/pkg/apis/core/v1beta1/validation/validation.go
+++ b/pkg/apis/core/v1beta1/validation/validation.go
@@ -190,14 +190,6 @@ func validateAPIEndpoint(endpoint string, path *field.Path) field.ErrorList {
 
 	allErrs := validateEnumStrings(path, hostURL.Scheme, []string{"http", "https"})
 
-	hostname := hostURL.Hostname()
-	dnsErrs := valutil.IsDNS1123Subdomain(hostname)
-	ipErrs := valutil.IsValidIP(hostname)
-	if dnsErrs != nil && ipErrs != nil {
-		combinedErrMsg := fmt.Sprintf("%s; or %s", strings.Join(ipErrs, ","), strings.Join(dnsErrs, ","))
-		allErrs = append(allErrs, field.Invalid(path, hostname, combinedErrMsg))
-	} // else one of the two succeeded
-
 	port := hostURL.Port()
 	if port != "" {
 		portInt, err := strconv.Atoi(port)

--- a/pkg/apis/core/v1beta1/validation/validation_test.go
+++ b/pkg/apis/core/v1beta1/validation/validation_test.go
@@ -445,22 +445,6 @@ func TestValidateAPIEndpoint(t *testing.T) {
 			`apiEndpoint: Unsupported value: "tcp"`,
 		},
 		{
-			"example_com",
-			"lower case alphanumeric characters, '-' or '.'",
-		},
-		{
-			"-example.com",
-			"must start and end with an alphanumeric character",
-		},
-		{
-			"192.0.2..161",
-			`apiEndpoint: Invalid value: "192.0.2..161": must be a valid IP address`,
-		},
-		{
-			"[2001:db8:25a4::8d2::1]",
-			`apiEndpoint: Invalid value: "2001:db8:25a4::8d2::1": must be a valid IP address`,
-		},
-		{
 			"example.com:port80",
 			`apiEndpoint: Invalid value: "example.com:port80": parse https://example.com:port80: invalid port ":port80" after host`,
 		},


### PR DESCRIPTION
This relaxes the KubeFedCluster APIEndpoint validation to more closely match what k8s does. While this will avoid catching some errors such as invalid IP addresses (e.g. multiple dots) and some DNS 1123 non-compliant URLs, it will be more accepting to some examples as captured in #1148.

Fixes #1148 