### PR TITLE
Return created kubefedcluster from JoinCluster

### DIFF
--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -98,7 +98,7 @@ var _ = Describe("Simulated Scale", func() {
 			memberClusters = append(memberClusters, memberCluster)
 			joiningNamespace := memberCluster
 
-			err := kubefedctl.TestOnly_JoinClusterForNamespace(
+			_, err := kubefedctl.TestOnly_JoinClusterForNamespace(
 				hostConfig, hostConfig, hostNamespace,
 				joiningNamespace, hostCluster, memberCluster,
 				"", apiextv1b1.NamespaceScoped, false, false)


### PR DESCRIPTION
**What this PR does / why we need it**:

When using kubefed as a library, returning the created `kubefedcluster` is very useful to be able to set references, ownership, etc after successful creation.