### PR TITLE
Code linting and other minor normalizations 

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -260,13 +260,12 @@ func setDefaultKubeFedConfigScope(fedConfig *corev1b1.KubeFedConfig) bool {
 			fedConfig.Spec.Scope = apiextv1b1.ResourceScope(defaultScope)
 			klog.Infof("Setting the scope of KubeFedConfig spec to %s", defaultScope)
 			return true
-		} else {
-			if fedConfig.Spec.Scope != apiextv1b1.ResourceScope(defaultScope) {
-				klog.Infof("Setting the scope of KubeFedConfig spec from %s to %s",
-					string(fedConfig.Spec.Scope), defaultScope)
-				fedConfig.Spec.Scope = apiextv1b1.ResourceScope(defaultScope)
-				return true
-			}
+		}
+		if fedConfig.Spec.Scope != apiextv1b1.ResourceScope(defaultScope) {
+			klog.Infof("Setting the scope of KubeFedConfig spec from %s to %s",
+				string(fedConfig.Spec.Scope), defaultScope)
+			fedConfig.Spec.Scope = apiextv1b1.ResourceScope(defaultScope)
+			return true
 		}
 	}
 	return false

--- a/cmd/controller-manager/app/leaderelection/leaderelection.go
+++ b/cmd/controller-manager/app/leaderelection/leaderelection.go
@@ -41,7 +41,7 @@ func NewKubeFedLeaderElector(opts *options.Options, fnStartControllers func(*opt
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		klog.Infof("unable to get hostname: %v", err)
+		klog.Errorf("unable to get hostname: %v", err)
 		return nil, err
 	}
 
@@ -62,7 +62,7 @@ func NewKubeFedLeaderElector(opts *options.Options, fnStartControllers func(*opt
 			EventRecorder: eventRecorder,
 		})
 	if err != nil {
-		klog.Infof("couldn't create resource lock: %v", err)
+		klog.Errorf("couldn't create resource lock: %v", err)
 		return nil, err
 	}
 

--- a/cmd/hyperfed/main.go
+++ b/cmd/hyperfed/main.go
@@ -141,7 +141,7 @@ func makeSymlinks(targetName string, commandFns []func() *cobra.Command) error {
 	}
 
 	if errs {
-		return errors.New("Error creating one or more symlinks.")
+		return errors.New("error creating one or more symlinks")
 	}
 	return nil
 }

--- a/pkg/controller/doc.go
+++ b/pkg/controller/doc.go
@@ -15,4 +15,3 @@ limitations under the License.
 */
 
 package controller
-

--- a/pkg/controller/kubefedcluster/clusterclient.go
+++ b/pkg/controller/kubefedcluster/clusterclient.go
@@ -81,7 +81,7 @@ func NewClusterClientSet(c *fedv1b1.KubeFedCluster, client generic.Client, fedNa
 }
 
 // GetClusterHealthStatus gets the kubernetes cluster health status by requesting "/healthz"
-func (self *ClusterClient) GetClusterHealthStatus() (*fedv1b1.KubeFedClusterStatus, error) {
+func (cc *ClusterClient) GetClusterHealthStatus() (*fedv1b1.KubeFedClusterStatus, error) {
 	clusterStatus := fedv1b1.KubeFedClusterStatus{}
 	currentTime := metav1.Now()
 	clusterReady := ClusterReady
@@ -124,9 +124,9 @@ func (self *ClusterClient) GetClusterHealthStatus() (*fedv1b1.KubeFedClusterStat
 		LastProbeTime:      currentTime,
 		LastTransitionTime: &currentTime,
 	}
-	body, err := self.kubeClient.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
+	body, err := cc.kubeClient.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
 	if err != nil {
-		runtime.HandleError(errors.Wrapf(err, "Failed to do cluster health check for cluster %q", self.clusterName))
+		runtime.HandleError(errors.Wrapf(err, "Failed to do cluster health check for cluster %q", cc.clusterName))
 		clusterStatus.Conditions = append(clusterStatus.Conditions, newClusterOfflineCondition)
 	} else {
 		if !strings.EqualFold(string(body), "ok") {
@@ -140,8 +140,8 @@ func (self *ClusterClient) GetClusterHealthStatus() (*fedv1b1.KubeFedClusterStat
 }
 
 // GetClusterZones gets the kubernetes cluster zones and region by inspecting labels on nodes in the cluster.
-func (self *ClusterClient) GetClusterZones() ([]string, string, error) {
-	nodes, err := self.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
+func (cc *ClusterClient) GetClusterZones() ([]string, string, error) {
+	nodes, err := cc.kubeClient.CoreV1().Nodes().List(metav1.ListOptions{})
 	if err != nil {
 		klog.Errorf("Failed to list nodes while getting zone names: %v", err)
 		return nil, "", err

--- a/pkg/controller/kubefedcluster/controller.go
+++ b/pkg/controller/kubefedcluster/controller.go
@@ -100,7 +100,7 @@ func newClusterController(config *util.ControllerConfig, clusterHealthCheckConfi
 	client := genericclient.NewForConfigOrDieWithUserAgent(kubeConfig, "cluster-controller")
 
 	cc := &ClusterController{
-		client:                   client,
+		client: client,
 		clusterHealthCheckConfig: clusterHealthCheckConfig,
 		clusterDataMap:           make(map[string]*ClusterData),
 		fedNamespace:             config.KubeFedNamespace,

--- a/pkg/controller/sync/resource.go
+++ b/pkg/controller/sync/resource.go
@@ -197,13 +197,13 @@ func (r *federatedResource) ObjectForCluster(clusterName string) (*unstructured.
 		namespace := util.NamespaceForCluster(clusterName, r.federatedResource.GetNamespace())
 		obj.SetNamespace(namespace)
 	}
-	targetApiResource := r.typeConfig.GetTargetType()
-	obj.SetKind(targetApiResource.Kind)
+	targetAPIResource := r.typeConfig.GetTargetType()
+	obj.SetKind(targetAPIResource.Kind)
 
 	// If the template does not specify an api version, default it to
 	// the one configured for the target type in the FTC.
 	if len(obj.GetAPIVersion()) == 0 {
-		obj.SetAPIVersion(fmt.Sprintf("%s/%s", targetApiResource.Group, targetApiResource.Version))
+		obj.SetAPIVersion(fmt.Sprintf("%s/%s", targetAPIResource.Group, targetAPIResource.Version))
 	}
 
 	return obj, nil
@@ -218,7 +218,7 @@ func (r *federatedResource) ApplyOverrides(obj *unstructured.Unstructured, clust
 		return err
 	}
 	if overrides != nil {
-		if err := util.ApplyJsonPatch(obj, overrides); err != nil {
+		if err := util.ApplyJSONPatch(obj, overrides); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -215,12 +215,12 @@ func NewFederatedInformer(
 			UpdateFunc: func(old, cur interface{}) {
 				oldCluster, ok := old.(*fedv1b1.KubeFedCluster)
 				if !ok {
-					klog.Errorf("Internal error: Cluster %v not updated.  Old cluster not of correct type.", old)
+					klog.Errorf("Internal error: Cluster %v not updated. Old cluster not of correct type.", old)
 					return
 				}
 				curCluster, ok := cur.(*fedv1b1.KubeFedCluster)
 				if !ok {
-					klog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
+					klog.Errorf("Internal error: Cluster %v not updated. New cluster not of correct type.", cur)
 					return
 				}
 				if IsClusterReady(&oldCluster.Status) != IsClusterReady(&curCluster.Status) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Labels, curCluster.ObjectMeta.Labels) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {

--- a/pkg/controller/util/overrides.go
+++ b/pkg/controller/util/overrides.go
@@ -159,8 +159,8 @@ func UnstructuredToInterface(rawObj *unstructured.Unstructured, obj interface{})
 	return json.Unmarshal(content, obj)
 }
 
-// ApplyJsonPatch applies the override on to the given unstructured object.
-func ApplyJsonPatch(obj *unstructured.Unstructured, overrides ClusterOverrides) error {
+// ApplyJSONPatch applies the override on to the given unstructured object.
+func ApplyJSONPatch(obj *unstructured.Unstructured, overrides ClusterOverrides) error {
 	// TODO: Do the defaulting of "op" field to "replace" in API defaulting
 	for i, overrideItem := range overrides {
 		if overrideItem.Op == "" {

--- a/pkg/controller/util/planner/planner.go
+++ b/pkg/controller/util/planner/planner.go
@@ -231,18 +231,17 @@ func (p *Planner) Plan(availableClusters []string, currentReplicaCount map[strin
 
 	if p.preferences.Spec.Rebalance {
 		return plan, overflow, nil
-	} else {
-		// If rebalance = false then overflow is trimmed at the level
-		// of replicas that it failed to place somewhere.
-		newOverflow := make(map[string]int64)
-		for key, value := range overflow {
-			value = minInt64(value, remainingReplicas)
-			if value > 0 {
-				newOverflow[key] = value
-			}
-		}
-		return plan, newOverflow, nil
 	}
+	// If rebalance = false then overflow is trimmed at the level
+	// of replicas that it failed to place somewhere.
+	newOverflow := make(map[string]int64)
+	for key, value := range overflow {
+		value = minInt64(value, remainingReplicas)
+		if value > 0 {
+			newOverflow[key] = value
+		}
+	}
+	return plan, newOverflow, nil
 }
 
 func minInt64(a int64, b int64) int64 {

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -15,4 +15,3 @@ limitations under the License.
 */
 
 package pkg
-

--- a/pkg/kubefedctl/disable.go
+++ b/pkg/kubefedctl/disable.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	disable_long = `
+	disableLong = `
 		Disables propagation of a Kubernetes API type. This command
 		can also optionally delete the API resources added by the enable
 		command.
@@ -58,7 +58,7 @@ var (
 		the kubefed control plane. Please use the
 		--host-cluster-context flag otherwise.`
 
-	disable_example = `
+	disableExample = `
 		# Disable propagation of the kubernetes API type 'Deployment', named
 		in FederatedTypeConfig as 'deployments.apps'
 		kubefedctl disable deployments.apps
@@ -94,8 +94,8 @@ func NewCmdTypeDisable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "disable NAME",
 		Short:   "Disables propagation of a Kubernetes API type",
-		Long:    disable_long,
-		Example: disable_example,
+		Long:    disableLong,
+		Example: disableExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {

--- a/pkg/kubefedctl/disable.go
+++ b/pkg/kubefedctl/disable.go
@@ -50,7 +50,7 @@ const (
 
 var (
 	disable_long = `
-		Disables propagation of a Kubernetes API type.  This command
+		Disables propagation of a Kubernetes API type. This command
 		can also optionally delete the API resources added by the enable
 		command.
 

--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -51,7 +51,7 @@ const (
 var (
 	enable_long = `
 		Enables a Kubernetes API type (including a CRD) to be propagated
-		to clusters registered with a KubeFed control plane.  A CRD for
+		to clusters registered with a KubeFed control plane. A CRD for
 		the federated type will be generated and a FederatedTypeConfig will
 		be created to configure a sync controller.
 

--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -86,8 +86,8 @@ type enableTypeOptions struct {
 // argument.
 func (o *enableTypeOptions) Bind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.federatedVersion, "federated-version", options.DefaultFederatedVersion, "The API version to use for the generated federated type.")
-	flags.StringVarP(&o.output, "output", "o", "", "If provided, the resources that would be created in the API by the command are instead output to stdout in the provided format.  Valid values are ['yaml'].")
-	flags.StringVarP(&o.filename, "filename", "f", "", "If provided, the command will be configured from the provided yaml file.  Only --output will be accepted from the command line")
+	flags.StringVarP(&o.output, "output", "o", "", "If provided, the resources that would be created in the API by the command are instead output to stdout in the provided format. Valid values are ['yaml'].")
+	flags.StringVarP(&o.filename, "filename", "f", "", "If provided, the command will be configured from the provided yaml file. Only --output will be accepted from the command line.")
 }
 
 // NewCmdTypeEnable defines the `enable` command that

--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	enable_long = `
+	enableLong = `
 		Enables a Kubernetes API type (including a CRD) to be propagated
 		to clusters registered with a KubeFed control plane. A CRD for
 		the federated type will be generated and a FederatedTypeConfig will
@@ -59,7 +59,7 @@ var (
 		the kubefed control plane. Please use the
 		--host-cluster-context flag otherwise.`
 
-	enable_example = `
+	enableExample = `
 		# Enable federation of Deployments
 		kubefedctl enable deployments.apps --host-cluster-context=cluster1
 
@@ -98,8 +98,8 @@ func NewCmdTypeEnable(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "enable (NAME | -f FILENAME)",
 		Short:   "Enables propagation of a Kubernetes API type",
-		Long:    enable_long,
-		Example: enable_example,
+		Long:    enableLong,
+		Example: enableExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -56,7 +56,7 @@ var (
 		"propagatedversions.core.kubefed.io",
 	}
 
-	federate_long = `
+	federateLong = `
 		Federate creates a federated resource from a kubernetes resource.
 		The target resource must exist in the cluster hosting the kubefed
 		control plane. If the federated resource needs to be created in the
@@ -69,7 +69,7 @@ var (
 		the kubefed control plane. Please use the --host-cluster-context
 		flag otherwise.`
 
-	federate_example = `
+	federateExample = `
 		# Federate resource named "my-cm" in namespace "my-ns" of kubernetes type "configmaps" (identified by short name "cm")
 		kubefedctl federate cm "my-cm" -n "my-ns" --host-cluster-context=cluster1`
 )
@@ -107,7 +107,7 @@ func (j *federateResource) Complete(args []string) error {
 
 	if len(j.filename) > 0 {
 		if len(args) > 0 {
-			return errors.Errorf("Flag '--filename' does not take any args. Got args: %v", args)
+			return errors.Errorf("flag '--filename' does not take any args. Got args: %v", args)
 		}
 		return nil
 	}
@@ -137,8 +137,8 @@ func NewCmdFederateResource(cmdOut io.Writer, config util.FedConfig) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:     "federate TYPE-NAME RESOURCE-NAME",
 		Short:   "Federate creates a federated resource from a kubernetes resource",
-		Long:    federate_long,
-		Example: federate_example,
+		Long:    federateLong,
+		Example: federateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
@@ -206,7 +206,7 @@ func (j *federateResource) Run(cmdOut io.Writer, config util.FedConfig) error {
 
 	kind := artifacts.typeConfig.GetTargetType().Kind
 	if kind != ctlutil.NamespaceKind && j.federateContents {
-		return errors.New("Flag '--contents' can only be used with type 'namespaces'.")
+		return errors.New("flag '--contents' can only be used with type 'namespaces'")
 	}
 
 	if kind == ctlutil.NamespaceKind && j.federateContents {

--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -89,7 +89,7 @@ type federateResource struct {
 
 func (j *federateResource) Bind(flags *pflag.FlagSet) {
 	flags.StringVarP(&j.resourceNamespace, "namespace", "n", "", "The namespace of the resource to federate.")
-	flags.StringVarP(&j.output, "output", "o", "", "If provided, the resource that would be created in the API by the command is instead output to stdout in the provided format.  Valid format is ['yaml'].")
+	flags.StringVarP(&j.output, "output", "o", "", "If provided, the resource that would be created in the API by the command is instead output to stdout in the provided format. Valid format is ['yaml'].")
 	flags.BoolVarP(&j.enableType, "enable-type", "t", false, "If true, attempt to enable federation of the API type of the resource before creating the federated resource.")
 	flags.BoolVarP(&j.federateContents, "contents", "c", false, "Applicable only to namespaces. If provided, the command will federate all resources within the namespace after federating the namespace.")
 	flags.StringVarP(&j.filename, "filename", "f", "", "If specified, the provided yaml file will be used as the input for target resources to federate. This mode will only emit federated resource yaml to standard output. Other flag options if provided will be ignored.")

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -50,14 +50,14 @@ const (
 )
 
 var (
-	join_long = `
+	joinLong = `
 		Join registers a Kubernetes cluster with a KubeFed control
 		plane.
 
 		Current context is assumed to be a Kubernetes cluster
 		hosting a KubeFed control plane. Please use the
 		--host-cluster-context flag otherwise.`
-	join_example = `
+	joinExample = `
 		# Register a cluster with a KubeFed control plane by
 		# specifying the cluster name and the context name of
 		# the control plane's host cluster. Cluster name must
@@ -113,8 +113,8 @@ func NewCmdJoin(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "join CLUSTER_NAME --host-cluster-context=HOST_CONTEXT",
 		Short:   "Register a cluster with a KubeFed control plane",
-		Long:    join_long,
-		Example: join_example,
+		Long:    joinLong,
+		Example: joinExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {
@@ -284,7 +284,7 @@ func joinClusterForNamespace(hostConfig, clusterConfig *rest.Config, kubefedName
 }
 
 // This function is exported for testing purposes only.
-var TestOnly_JoinClusterForNamespace = joinClusterForNamespace
+var TestOnlyJoinClusterForNamespace = joinClusterForNamespace
 
 // performPreflightChecks checks that the host and joining clusters are in
 // a consistent state.

--- a/pkg/kubefedctl/options/options.go
+++ b/pkg/kubefedctl/options/options.go
@@ -44,7 +44,7 @@ type GlobalSubcommandOptions struct {
 // GlobalSubcommandBind adds the global subcommand flags to the flagset passed in.
 func (o *GlobalSubcommandOptions) GlobalSubcommandBind(flags *pflag.FlagSet) {
 	flags.StringVar(&o.Kubeconfig, "kubeconfig", "", "Path to the kubeconfig file to use for CLI requests.")
-	flags.StringVar(&o.HostClusterContext, "host-cluster-context", "", "Host cluster context")
+	flags.StringVar(&o.HostClusterContext, "host-cluster-context", "", "Host cluster context.")
 	flags.StringVar(&o.KubeFedNamespace, "kubefed-namespace", util.DefaultKubeFedSystemNamespace,
 		"Namespace in the host cluster where the KubeFed system components are installed. This namespace will also be the target of propagation if the controller manager is running with namespaced scope.")
 	flags.BoolVar(&o.DryRun, "dry-run", false,

--- a/pkg/kubefedctl/orphaning/disable.go
+++ b/pkg/kubefedctl/orphaning/disable.go
@@ -30,7 +30,7 @@ import (
 )
 
 var (
-	orphaning_disable_long = `
+	orphaningDisableLong = `
 		Removes previously added "orphaning enable" ('kubefed.io/orphan: true')
 		annotation from a federated resource. When the federated resource is subsequently marked for deletion,
 		the resources it manages in member clusters will be removed before the federated resource is removed.
@@ -39,7 +39,7 @@ var (
 		the kubefed control plane. Please use the
 		--host-cluster-context flag otherwise.`
 
-	orphaning_disable_example = `
+	orphaningDisableExample = `
 		# Disable the orphaning mode for a federated resource of type FederatedDeployment and named foo
 		kubefedctl orphaning disable FederatedDeployment foo --host-cluster-context=cluster1`
 )
@@ -50,8 +50,8 @@ func newCmdDisableOrphaning(cmdOut io.Writer, config util.FedConfig) *cobra.Comm
 	cmd := &cobra.Command{
 		Use:     "disable <resource type> <resource name>",
 		Short:   "Disable orphaning deletion to ensure the removal of managed resources before removing the managing federated resource",
-		Long:    orphaning_disable_long,
-		Example: orphaning_disable_example,
+		Long:    orphaningDisableLong,
+		Example: orphaningDisableExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args, config)
 			if err != nil {

--- a/pkg/kubefedctl/orphaning/disable.go
+++ b/pkg/kubefedctl/orphaning/disable.go
@@ -32,7 +32,7 @@ import (
 var (
 	orphaning_disable_long = `
 		Removes previously added "orphaning enable" ('kubefed.io/orphan: true')
-		annotation from a federated resource.  When the federated resource is subsequently marked for deletion,
+		annotation from a federated resource. When the federated resource is subsequently marked for deletion,
 		the resources it manages in member clusters will be removed before the federated resource is removed.
 
 		Current context is assumed to be a Kubernetes cluster hosting
@@ -40,7 +40,7 @@ var (
 		--host-cluster-context flag otherwise.`
 
 	orphaning_disable_example = `
-		# Disable the orphaning mode for a federated resource of type FederatedDeployment and named foo 
+		# Disable the orphaning mode for a federated resource of type FederatedDeployment and named foo
 		kubefedctl orphaning disable FederatedDeployment foo --host-cluster-context=cluster1`
 )
 

--- a/pkg/kubefedctl/orphaning/enable.go
+++ b/pkg/kubefedctl/orphaning/enable.go
@@ -30,17 +30,17 @@ import (
 )
 
 var (
-	orphaning_enable_long = `
-		Prevents the removal of managed resources from member clusters when their managing federated 
-		resource is removed. This is accomplished by adding 'kubefed.io/orphan: true' as an annotation to the 
+	orphaningEnableLong = `
+		Prevents the removal of managed resources from member clusters when their managing federated
+		resource is removed. This is accomplished by adding 'kubefed.io/orphan: true' as an annotation to the
 		federated resource.
 
 		Current context is assumed to be a Kubernetes cluster hosting
 		the kubefed control plane. Please use the
 		--host-cluster-context flag otherwise.`
 
-	orphan_enable_example = `
-		# Enable the orphaning mode for a federated resource of type FederatedDeployment and named foo 
+	orphanEnableExample = `
+		# Enable the orphaning mode for a federated resource of type FederatedDeployment and named foo
 		kubefedctl orphaning enable FederatedDeployment foo --host-cluster-context=cluster1`
 )
 
@@ -50,8 +50,8 @@ func newCmdEnableOrphaning(cmdOut io.Writer, config util.FedConfig) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:     "enable <resource type> <resource name>",
 		Short:   "Enable the orphaning (i.e. retention) of resources managed by a federated resource upon its removal.",
-		Long:    orphaning_enable_long,
-		Example: orphan_enable_example,
+		Long:    orphaningEnableLong,
+		Example: orphanEnableExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args, config)
 			if err != nil {

--- a/pkg/kubefedctl/orphaning/orphaning.go
+++ b/pkg/kubefedctl/orphaning/orphaning.go
@@ -45,7 +45,7 @@ type orphanResource struct {
 
 // Bind adds the join specific arguments to the flagset passed in as an argument.
 func (o *orphanResource) Bind(flags *pflag.FlagSet) error {
-	flags.StringVarP(&o.resourceNamespace, "namespace", "n", "", "If present, the namespace scope for this CLI request")
+	flags.StringVarP(&o.resourceNamespace, "namespace", "n", "", "If present, the namespace scope for this CLI request.")
 	err := flags.MarkHidden("kubefed-namespace")
 	if err != nil {
 		return err

--- a/pkg/kubefedctl/orphaning/status.go
+++ b/pkg/kubefedctl/orphaning/status.go
@@ -33,15 +33,15 @@ const (
 )
 
 var (
-	orphaning_status_long = `
-		Checks the status of "orphaning enable" ('kubefed.io/orphan: true') annotation on a federated resource. 
+	orphaningStatusLong = `
+		Checks the status of "orphaning enable" ('kubefed.io/orphan: true') annotation on a federated resource.
 		Returns "Enabled" or "Disabled"
 
-		Current context is assumed to be a Kubernetes cluster hosting the kubefed control plane. 
+		Current context is assumed to be a Kubernetes cluster hosting the kubefed control plane.
 		Please use the --host-cluster-context flag otherwise.`
 
-	orphaning_status_example = `
-		# Checks the status of the orphaning mode of a federated resource of type FederatedDeployment and named foo 
+	orphaningStatusExample = `
+		# Checks the status of the orphaning mode of a federated resource of type FederatedDeployment and named foo
 		kubefedctl orphaning status FederatedDeployment foo --host-cluster-context=cluster1`
 )
 
@@ -51,8 +51,8 @@ func newCmdStatusOrphaning(cmdOut io.Writer, config util.FedConfig) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:     "status <resource type> <resource name>",
 		Short:   "Get the orphaning deletion status of the federated resource",
-		Long:    orphaning_status_long,
-		Example: orphaning_status_example,
+		Long:    orphaningStatusLong,
+		Example: orphaningStatusExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args, config)
 			if err != nil {

--- a/pkg/kubefedctl/unjoin.go
+++ b/pkg/kubefedctl/unjoin.go
@@ -40,13 +40,13 @@ import (
 )
 
 var (
-	unjoin_long = `
+	unjoinLong = `
 		Unjoin removes the registration of a Kubernetes cluster
 		from a KubeFed control plane. Current context is assumed
 		to be a Kubernetes cluster hosting a KubeFed control
 		plane. Please use the --host-cluster-context flag
 		otherwise.`
-	unjoin_example = `
+	unjoinExample = `
 		# Remove the registration of a Kubernetes cluster
 		# from a KubeFed control plane by specifying the
 		# cluster name and the context name of the control
@@ -82,8 +82,8 @@ func NewCmdUnjoin(cmdOut io.Writer, config util.FedConfig) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "unjoin CLUSTER_NAME --host-cluster-context=HOST_CONTEXT",
 		Short:   "Remove the registration of a cluster from a KubeFed control plane",
-		Long:    unjoin_long,
-		Example: unjoin_example,
+		Long:    unjoinLong,
+		Example: unjoinExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := opts.Complete(args)
 			if err != nil {

--- a/pkg/kubefedctl/version.go
+++ b/pkg/kubefedctl/version.go
@@ -26,9 +26,9 @@ import (
 )
 
 var (
-	version_long = `
+	versionLong = `
 		Version prints the version info of this command.`
-	version_example = `
+	versionExample = `
 		# Print kubefed command version
 		kubefed version`
 )
@@ -38,8 +38,8 @@ func NewCmdVersion(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "version",
 		Short:   "Print the version info",
-		Long:    version_long,
-		Example: version_example,
+		Long:    versionLong,
+		Example: versionExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Fprintf(out, "kubefedctl version: %s\n", fmt.Sprintf("%#v", version.Get()))
 		},

--- a/pkg/schedulingtypes/plugin.go
+++ b/pkg/schedulingtypes/plugin.go
@@ -252,7 +252,7 @@ func OverrideUpdateNeeded(overridesMap util.OverridesMap, result map[string]int6
 			if !ok || value != replicas {
 				return true
 			}
-			checkLen += 1
+			checkLen++
 		}
 	}
 

--- a/test/common/bindata.go
+++ b/test/common/bindata.go
@@ -47,6 +47,7 @@ import (
 	"strings"
 	"time"
 )
+
 type asset struct {
 	bytes []byte
 	info  os.FileInfo
@@ -751,34 +752,34 @@ type bintree struct {
 }
 
 var _bintree = &bintree{nil, map[string]*bintree{
-	"config": &bintree{nil, map[string]*bintree{
-		"enabletypedirectives": &bintree{nil, map[string]*bintree{
-			"clusterroles.rbac.authorization.k8s.io.yaml": &bintree{configEnabletypedirectivesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
-			"configmaps.yaml":                             &bintree{configEnabletypedirectivesConfigmapsYaml, map[string]*bintree{}},
-			"deployments.apps.yaml":                       &bintree{configEnabletypedirectivesDeploymentsAppsYaml, map[string]*bintree{}},
-			"ingresses.extensions.yaml":                   &bintree{configEnabletypedirectivesIngressesExtensionsYaml, map[string]*bintree{}},
-			"jobs.batch.yaml":                             &bintree{configEnabletypedirectivesJobsBatchYaml, map[string]*bintree{}},
-			"namespaces.yaml":                             &bintree{configEnabletypedirectivesNamespacesYaml, map[string]*bintree{}},
-			"replicasets.apps.yaml":                       &bintree{configEnabletypedirectivesReplicasetsAppsYaml, map[string]*bintree{}},
-			"secrets.yaml":                                &bintree{configEnabletypedirectivesSecretsYaml, map[string]*bintree{}},
-			"serviceaccounts.yaml":                        &bintree{configEnabletypedirectivesServiceaccountsYaml, map[string]*bintree{}},
-			"services.yaml":                               &bintree{configEnabletypedirectivesServicesYaml, map[string]*bintree{}},
+	"config": {nil, map[string]*bintree{
+		"enabletypedirectives": {nil, map[string]*bintree{
+			"clusterroles.rbac.authorization.k8s.io.yaml": {configEnabletypedirectivesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
+			"configmaps.yaml":                             {configEnabletypedirectivesConfigmapsYaml, map[string]*bintree{}},
+			"deployments.apps.yaml":                       {configEnabletypedirectivesDeploymentsAppsYaml, map[string]*bintree{}},
+			"ingresses.extensions.yaml":                   {configEnabletypedirectivesIngressesExtensionsYaml, map[string]*bintree{}},
+			"jobs.batch.yaml":                             {configEnabletypedirectivesJobsBatchYaml, map[string]*bintree{}},
+			"namespaces.yaml":                             {configEnabletypedirectivesNamespacesYaml, map[string]*bintree{}},
+			"replicasets.apps.yaml":                       {configEnabletypedirectivesReplicasetsAppsYaml, map[string]*bintree{}},
+			"secrets.yaml":                                {configEnabletypedirectivesSecretsYaml, map[string]*bintree{}},
+			"serviceaccounts.yaml":                        {configEnabletypedirectivesServiceaccountsYaml, map[string]*bintree{}},
+			"services.yaml":                               {configEnabletypedirectivesServicesYaml, map[string]*bintree{}},
 		}},
-		"kubefedconfig.yaml": &bintree{configKubefedconfigYaml, map[string]*bintree{}},
+		"kubefedconfig.yaml": {configKubefedconfigYaml, map[string]*bintree{}},
 	}},
-	"test": &bintree{nil, map[string]*bintree{
-		"common": &bintree{nil, map[string]*bintree{
-			"fixtures": &bintree{nil, map[string]*bintree{
-				"clusterroles.rbac.authorization.k8s.io.yaml": &bintree{testCommonFixturesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
-				"configmaps.yaml":                             &bintree{testCommonFixturesConfigmapsYaml, map[string]*bintree{}},
-				"deployments.apps.yaml":                       &bintree{testCommonFixturesDeploymentsAppsYaml, map[string]*bintree{}},
-				"ingresses.extensions.yaml":                   &bintree{testCommonFixturesIngressesExtensionsYaml, map[string]*bintree{}},
-				"jobs.batch.yaml":                             &bintree{testCommonFixturesJobsBatchYaml, map[string]*bintree{}},
-				"namespaces.yaml":                             &bintree{testCommonFixturesNamespacesYaml, map[string]*bintree{}},
-				"replicasets.apps.yaml":                       &bintree{testCommonFixturesReplicasetsAppsYaml, map[string]*bintree{}},
-				"secrets.yaml":                                &bintree{testCommonFixturesSecretsYaml, map[string]*bintree{}},
-				"serviceaccounts.yaml":                        &bintree{testCommonFixturesServiceaccountsYaml, map[string]*bintree{}},
-				"services.yaml":                               &bintree{testCommonFixturesServicesYaml, map[string]*bintree{}},
+	"test": {nil, map[string]*bintree{
+		"common": {nil, map[string]*bintree{
+			"fixtures": {nil, map[string]*bintree{
+				"clusterroles.rbac.authorization.k8s.io.yaml": {testCommonFixturesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
+				"configmaps.yaml":                             {testCommonFixturesConfigmapsYaml, map[string]*bintree{}},
+				"deployments.apps.yaml":                       {testCommonFixturesDeploymentsAppsYaml, map[string]*bintree{}},
+				"ingresses.extensions.yaml":                   {testCommonFixturesIngressesExtensionsYaml, map[string]*bintree{}},
+				"jobs.batch.yaml":                             {testCommonFixturesJobsBatchYaml, map[string]*bintree{}},
+				"namespaces.yaml":                             {testCommonFixturesNamespacesYaml, map[string]*bintree{}},
+				"replicasets.apps.yaml":                       {testCommonFixturesReplicasetsAppsYaml, map[string]*bintree{}},
+				"secrets.yaml":                                {testCommonFixturesSecretsYaml, map[string]*bintree{}},
+				"serviceaccounts.yaml":                        {testCommonFixturesServiceaccountsYaml, map[string]*bintree{}},
+				"services.yaml":                               {testCommonFixturesServicesYaml, map[string]*bintree{}},
 			}},
 		}},
 	}},

--- a/test/common/crudtester.go
+++ b/test/common/crudtester.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
-
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -326,7 +325,7 @@ func (c *FederatedTypeCrudTester) CheckDelete(fedObject *unstructured.Unstructur
 	targetKind := c.typeConfig.GetTargetType().Kind
 
 	// TODO(marun) Consider using informer to detect expected deletion state.
-	var stateMsg string = "unlabeled"
+	var stateMsg = "unlabeled"
 	if deletingInCluster {
 		stateMsg = "not present"
 	}
@@ -561,7 +560,7 @@ func (c *FederatedTypeCrudTester) waitForResource(client util.ResourceClient, qu
 			if len(expectedOverrides) > 0 {
 				expectedClusterObject := clusterObj.DeepCopy()
 				// Applying overrides on copy of received cluster object should not change the cluster object if the overrides are properly applied.
-				if err := util.ApplyJsonPatch(expectedClusterObject, expectedOverrides); err != nil {
+				if err := util.ApplyJSONPatch(expectedClusterObject, expectedOverrides); err != nil {
 					c.tl.Fatalf("Failed to apply json patch: %v", err)
 				}
 

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -34,7 +34,7 @@ import (
 // This function is called on each Ginkgo node in parallel mode.
 func RunE2ETests(t *testing.T) {
 	gomega.RegisterFailHandler(ginkgowrapper.Fail)
-	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
+	klog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunID, config.GinkgoConfig.ParallelNode)
 	ginkgo.RunSpecs(t, "KubeFed e2e suite")
 }
 

--- a/test/e2e/federate.go
+++ b/test/e2e/federate.go
@@ -72,7 +72,7 @@ var _ = Describe("Federate ", func() {
 	for _, testKey := range toTest {
 		typeConfigName := testKey
 		fixture := typeConfigFixtures[testKey]
-		It(fmt.Sprintf("resource %q, should create an equivalant federated resource in the host cluster", typeConfigName), func() {
+		It(fmt.Sprintf("resource %q, should create an equivalent federated resource in the host cluster", typeConfigName), func() {
 			typeConfig := &fedv1b1.FederatedTypeConfig{}
 			err := client.Get(context.Background(), typeConfig, f.KubeFedSystemNamespace(), typeConfigName)
 			if err != nil {
@@ -121,7 +121,7 @@ var _ = Describe("Federate ", func() {
 		})
 	}
 
-	It("namespace with contents, should create equivalant federated resources for all namespaced resources", func() {
+	It("namespace with contents, should create equivalent federated resources for all namespaced resources", func() {
 		if framework.TestContext.LimitedScope {
 			framework.Skipf("Federate namespace with content is not tested when control plane is namespace scoped")
 		}
@@ -176,7 +176,7 @@ var _ = Describe("Federate ", func() {
 		validateResourcesEqualityFromAPI(tl, createdTargetResources, kubeConfig)
 	})
 
-	It("input yaml from a file, should emit equivalant federated resources", func() {
+	It("input yaml from a file, should emit equivalent federated resources", func() {
 		tmpFile, err := ioutil.TempFile("", "tmp-")
 		if err != nil {
 			tl.Fatalf("Error creating temperory file: %v", err)

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -53,7 +53,7 @@ func (t *TestContextType) NamespaceScopedControlPlane() bool {
 	return t.InMemoryControllers && t.LimitedScopeInMemoryControllers || t.LimitedScope
 }
 
-var TestContext *TestContextType = &TestContextType{}
+var TestContext TestContextType = &TestContextType{}
 
 func registerFlags(t *TestContextType) {
 	flag.BoolVar(&t.InMemoryControllers, "in-memory-controllers", false,

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -37,8 +37,8 @@ const (
 	DefaultSingleCallTimeout = 30 * time.Second
 )
 
-// unique identifier of the e2e run
-var RunId = uuid.NewUUID()
+// RunID unique identifier of the e2e run
+var RunID = uuid.NewUUID()
 
 func nowStamp() string {
 	return time.Now().Format(time.StampMilli)

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -98,7 +98,7 @@ var _ = Describe("Simulated Scale", func() {
 			memberClusters = append(memberClusters, memberCluster)
 			joiningNamespace := memberCluster
 
-			_, err := kubefedctl.TestOnly_JoinClusterForNamespace(
+			_, err := kubefedctl.TestOnlyJoinClusterForNamespace(
 				hostConfig, hostConfig, hostNamespace,
 				joiningNamespace, hostCluster, memberCluster,
 				"", apiextv1b1.NamespaceScoped, false, false)


### PR DESCRIPTION
**What this PR does / why we need it**:

We are using kubefed and while I was checking the code, I found certain code that was non-idiomatic golang code. I also found some other minor chores that I also addressed as part of this PR:
- Flags: I normalized the descriptions in all commands to end with a dot `.` for consistency.
- golint: Ran golint and fixed major code errors. I avoided bigger changes in type names such as `type name will be used as federate.FederateArtifacts by other packages, and that stutters; consider calling this Artifacts`. Perhaps it'd be good to include golint as part of the CI pipeline at some point.
- Fixed a typo in e2e/federate.go.
- cmd/controller-manager/app/leaderelection: log errors in leader election
- gofmt two files. (doc.go)

I hope you find it helpful.

**Special notes for your reviewer**:
Please, let me know if you want me to create a separate PR with any of the commits. I think the current changes are high in number but easy to identify.