### PR TITLE
check managed=false in member cluster

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -454,6 +454,7 @@ The following table enumerates the possible values for cluster status:
 | FieldRetentionFailed   | An error occurred while attempting to retain the value of one or more fields in the target resource (e.g. `clusterIP` for a service) |
 | LabelRemovalFailed     | Removal of the KubeFed label from the target resource failed. |
 | LabelRemovalTimedOut   | Removal of the KubeFed label from the target resource timed out. |
+| ManagedLabelFalse      | Unable to manage the object which has label kubefed.io/managed: false |
 | RetrievalFailed        | Retrievel of the target resource from the cluster failed. |
 | UpdateFailed           | Update of the target resource failed. |
 | UpdateTimedOut         | Update of the target resource timed out. |

--- a/pkg/controller/sync/dispatch/managed.go
+++ b/pkg/controller/sync/dispatch/managed.go
@@ -185,6 +185,11 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 	d.dispatcher.incrementOperationsInitiated()
 	const op = "update"
 	go d.dispatcher.clusterOperation(clusterName, op, func(client generic.Client) util.ReconciliationStatus {
+		if util.IsExplicitlyUnmanaged(clusterObj) {
+			err := errors.Errorf("Unable to manage the object which has label %s: %s", util.ManagedByKubeFedLabelKey, util.UnmanagedByKubeFedLabelValue)
+			return d.recordOperationError(status.ManagedLabelFalse, clusterName, op, err)
+		}
+
 		obj, err := d.fedResource.ObjectForCluster(clusterName)
 		if err != nil {
 			return d.recordOperationError(status.ComputeResourceFailed, clusterName, op, err)

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -53,6 +53,7 @@ const (
 	FieldRetentionFailed   PropagationStatus = "FieldRetentionFailed"
 	VersionRetrievalFailed PropagationStatus = "VersionRetrievalFailed"
 	ClientRetrievalFailed  PropagationStatus = "ClientRetrievalFailed"
+	ManagedLabelFalse      PropagationStatus = "ManagedLabelFalse"
 
 	// Operation timeout errors
 	CreationTimedOut     PropagationStatus = "CreationTimedOut"

--- a/pkg/controller/util/managedlabel.go
+++ b/pkg/controller/util/managedlabel.go
@@ -21,8 +21,9 @@ import (
 )
 
 const (
-	ManagedByKubeFedLabelKey   = "kubefed.io/managed"
-	ManagedByKubeFedLabelValue = "true"
+	ManagedByKubeFedLabelKey     = "kubefed.io/managed"
+	ManagedByKubeFedLabelValue   = "true"
+	UnmanagedByKubeFedLabelValue = "false"
 )
 
 // HasManagedLabel indicates whether the given object has the managed
@@ -33,6 +34,16 @@ func HasManagedLabel(obj *unstructured.Unstructured) bool {
 		return false
 	}
 	return labels[ManagedByKubeFedLabelKey] == ManagedByKubeFedLabelValue
+}
+
+// IsExplicitlyUnmanaged indicates whether the given object has the managed
+// label with value false.
+func IsExplicitlyUnmanaged(obj *unstructured.Unstructured) bool {
+	labels := obj.GetLabels()
+	if labels == nil {
+		return false
+	}
+	return labels[ManagedByKubeFedLabelKey] == UnmanagedByKubeFedLabelValue
 }
 
 // AddManagedLabel ensures that the given object has the managed


### PR DESCRIPTION
when a resource object in member cluster has managed label false, it should not be managed by the federated resource


This addresses partial of 1003


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
