### PR TITLE
fix typo

### DIFF
--- a/pkg/kubefedctl/enable/enable.go
+++ b/pkg/kubefedctl/enable/enable.go
@@ -308,7 +308,7 @@ func CreateResources(cmdOut io.Writer, config *rest.Config, resources *typeResou
 			fedType := ftc.Spec.FederatedType
 			name := typeconfig.GroupQualifiedName(metav1.APIResource{Name: fedType.PluralName, Group: fedType.Group})
 			if name == existingCRD.Name {
-				return errors.Errorf("Failed to enable federation of %q due to the FederatedTypeConfig for %q already referencing a federated type CRD named %q. If these target types are distinct despite sharing the same kind, specifying a non-default --federation-group should allow %q to be enabled.",
+				return errors.Errorf("Failed to enable federation of %q due to the FederatedTypeConfig for %q already referencing a federated type CRD named %q. If these target types are distinct despite sharing the same kind, specifying a non-default --federated-group should allow %q to be enabled.",
 					concreteTypeConfig.Name, ftc.Name, name, concreteTypeConfig.Name)
 			}
 		}


### PR DESCRIPTION
Following the docs deploying kubefed on OpenShift, I ended up on the following error:

```
# oc apply -R -f kubefed/example/sample1/
configmap/web-file created
deployment.apps/nginx created
federatedclusterrole.types.kubefed.io/test-clusterrole created
federatedconfigmap.types.kubefed.io/test-configmap created
federateddeployment.types.kubefed.io/test-deployment created
federatedingress.types.kubefed.io/test-ingress created
federatedjob.types.kubefed.io/test-job created
federatednamespace.types.kubefed.io/test-namespace unchanged
federatedsecret.types.kubefed.io/test-secret created
federatedservice.types.kubefed.io/test-service created
federatedserviceaccount.types.kubefed.io/test-serviceaccount created
namespace/test-namespace unchanged
service/nginx created
error: unable to recognize "kubefed/example/sample1/federatedclusterrolebinding.yaml": no matches for kind "FederatedClusterRoleBinding" in version "types.kubefed.io/v1beta1"
```

Tried to enable federation for ClusterRoleBindings, as follow:
```
# kubefedctl enable clusterrolebinding 
F1025 13:07:30.531848   20098 enable.go:110] Error: Multiple resources are matched by "clusterrolebinding": clusterrolebindings.rbac.authorization.k8s.io, clusterrolebindings.authorization.openshift.io. A group-qualified plural name must be provided.
```

Which works if I do the following:
```
$ kubefedctl enable clusterrolebindings.rbac.authorization.k8s.io
```

Though in doubt, I wanted to enable federation for clusterrolebindings in openshift API group as well, and then I hit with a new error:

```
# kubefedctl enable clusterrolebindings.authorization.openshift.io
F1025 13:10:12.847530   20142 enable.go:110] Error: Failed to enable federation of "clusterrolebindings.authorization.openshift.io" due to the FederatedTypeConfig for "clusterrolebindings.rbac.authorization.k8s.io" already referencing a federated type CRD named "federatedclusterrolebindings.types.kubefed.io". If these target types are distinct despite sharing the same kind, specifying a non-default --federation-group should allow "clusterrolebindings.authorization.openshift.io" to be enabled.
```

Following that errors recommentation, I tried to add some `--federation-group` option, only to hit with a new error:
```
 kubefedctl enable clusterrolebindings.authorization.openshift.io --federation-group authorization.openshift.io
Error: unknown flag: --federation-group
...
```

It appears the "right" option is `federated-group`, not `federation-group`:
```
kubefedctl enable clusterrolebindings.authorization.openshift.io --federated-group authorization.openshift.io
customresourcedefinition.apiextensions.k8s.io/federatedclusterrolebindings.authorization.openshift.io created
federatedtypeconfig.core.kubefed.io/clusterrolebindings.authorization.openshift.io created in namespace kube-federation-system
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
