### PR TITLE
charts: create aggregated cluster roles to the standard kubernetes roles

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
@@ -1,0 +1,133 @@
+{{- if or (not .Values.global.scope) (eq .Values.global.scope "Cluster") }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+  name: kubefed-admin
+rules:
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  name: kubefed-edit
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - update
+  - delete
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+  - create
+  - update
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    api: kubefed
+    kubebuilder.k8s.io: 1.0.0
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: kubefed-view
+rules:
+- apiGroups:
+  - scheduling.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - multiclusterdns.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - core.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+- apiGroups:
+  - types.kubefed.io
+  resources:
+  - '*'
+  verbs:
+  - get
+  - watch
+  - list
+{{- end }}

--- a/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
@@ -5,7 +5,6 @@ kind: ClusterRole
 metadata:
   labels:
     api: kubefed
-    kubebuilder.k8s.io: 1.0.0
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
   name: kubefed-admin
 rules:
@@ -39,7 +38,6 @@ kind: ClusterRole
 metadata:
   labels:
     api: kubefed
-    kubebuilder.k8s.io: 1.0.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
   name: kubefed-edit
 rules:
@@ -94,7 +92,6 @@ kind: ClusterRole
 metadata:
   labels:
     api: kubefed
-    kubebuilder.k8s.io: 1.0.0
     rbac.authorization.k8s.io/aggregate-to-view: "true"
   name: kubefed-view
 rules:

--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -215,12 +215,12 @@ func NewFederatedInformer(
 			UpdateFunc: func(old, cur interface{}) {
 				oldCluster, ok := old.(*fedv1b1.KubeFedCluster)
 				if !ok {
-					klog.Errorf("Internal error: Cluster %v not updated.  Old cluster not of correct type.", old)
+					klog.Errorf("Internal error: Cluster %v not updated. Old cluster not of correct type.", old)
 					return
 				}
 				curCluster, ok := cur.(*fedv1b1.KubeFedCluster)
 				if !ok {
-					klog.Errorf("Internal error: Cluster %v not updated.  New cluster not of correct type.", cur)
+					klog.Errorf("Internal error: Cluster %v not updated. New cluster not of correct type.", cur)
 					return
 				}
 				if IsClusterReady(&oldCluster.Status) != IsClusterReady(&curCluster.Status) || !reflect.DeepEqual(oldCluster.Spec, curCluster.Spec) || !reflect.DeepEqual(oldCluster.ObjectMeta.Labels, curCluster.ObjectMeta.Labels) || !reflect.DeepEqual(oldCluster.ObjectMeta.Annotations, curCluster.ObjectMeta.Annotations) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The kubefed cluster roles are not aggregated to default kubernetes cluster roles, as you could expect. That is a common practice to aggregate the rules of custom resources to the existing kubernetes cluster roles such as view, edit, admin. That'll keep the consistency and purpose of these cluster roles.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: fixes #1170 
Fixes #

**Special notes for your reviewer**:
