### PR TITLE
chore: Use distroless base image instead of alpine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 # Ignore binaries built by the makefile to avoid accidentally committing them
 /images/kubefed/hyperfed
 /images/kubefed/controller-manager
+/images/kubefed/kubefedctl
+/images/kubefed/webhook

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,10 @@ fmt:
 
 container: $(HYPERFED_TARGET)-linux-$(HOST_ARCH)
 	cp -f $(HYPERFED_TARGET)-linux-$(HOST_ARCH) images/kubefed/hyperfed
+	cd images/kubefed && \
+		ln -sf hyperfed controller-manager && \
+		ln -sf hyperfed kubefedctl && \
+		ln -sf hyperfed webhook
 	$(DOCKER) build images/kubefed -t $(IMAGE_NAME)
 	rm -f images/kubefed/hyperfed
 

--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -17,7 +17,7 @@ spec:
         kubefed-control-plane: controller-manager
     spec:
       securityContext:
-        runAsUser: 1001
+        runAsUser: 65534
       serviceAccountName: kubefed-controller
       containers:
       - command:
@@ -56,7 +56,7 @@ spec:
         kubefed-admission-webhook: "true"
     spec:
       securityContext:
-        runAsUser: 1001
+        runAsUser: 65534
       serviceAccountName: kubefed-admission-webhook
       containers:
       - name: admission-webhook
@@ -64,6 +64,7 @@ spec:
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         command:
         - "/hyperfed/webhook"
+        args:
         - "--secure-port=8443"
         - "--audit-log-path=-"
         - "--tls-cert-file=/var/serving-cert/tls.crt"

--- a/images/kubefed/Dockerfile
+++ b/images/kubefed/Dockerfile
@@ -12,20 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Use latest distroless non-root image.
+FROM gcr.io/distroless/static@sha256:23aa732bba4c8618c0d97c26a72a32997363d591807b0d4c31b0bbc8a774bddf
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-RUN adduser -D -g hyperfed -u 1001 hyperfed
+COPY /hyperfed /controller-manager /kubefedctl /webhook /hyperfed/
 
-RUN mkdir -p /hyperfed
-     
-WORKDIR /hyperfed/
-COPY /hyperfed .
-RUN ln -s hyperfed controller-manager \
- && ln -s hyperfed kubefedctl \
- && ln -s hyperfed webhook
-
-RUN chown -R hyperfed:hyperfed /hyperfed
-
-USER hyperfed
-ENTRYPOINT ["./controller-manager"]
+# Run as nobody.
+USER 65534
+ENTRYPOINT ["/hyperfed/hyperfed"]


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR uses distroless static non-root Docker base image using the standard `nobody` uid (`65534`). This simplifies the build in a (very) small way.