### PR TITLE
Make the chart  Helm 3 compliant while maintaining compatibility with Helm 2

### DIFF
--- a/charts/kubefed-crds/Chart.yaml
+++ b/charts/kubefed-crds/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+description: Custom resources definitions for KubeFed helm chart
+name: kubefed-crds
+version: 0.0.2

--- a/charts/kubefed-crds/crds/controllermanager-crds.yaml
+++ b/charts/kubefed-crds/crds/controllermanager-crds.yaml
@@ -1,0 +1,1170 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: clusterpropagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: ClusterPropagatedVersion
+    listKind: ClusterPropagatedVersionList
+    plural: clusterpropagatedversions
+    singular: clusterpropagatedversion
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ClusterPropagatedVersion holds version information about the state
+        propagated from KubeFed APIs (configured by FederatedTypeConfig resources)
+        to member clusters. The name of a ClusterPropagatedVersion encodes the kind
+        and name of the resource it stores information for (i.e. <lower-case kind>-<resource
+        name>). If a target resource has a populated metadata.Generation field, the
+        generation will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: federatedservicestatuses.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedServiceStatus
+    listKind: FederatedServiceStatusList
+    plural: federatedservicestatuses
+    singular: federatedservicestatus
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        clusterStatus:
+          items:
+            description: FederatedServiceClusterStatus is the observed status of the
+              resource for a named cluster
+            properties:
+              clusterName:
+                type: string
+              status:
+                description: ServiceStatus represents the current status of a service.
+                properties:
+                  loadBalancer:
+                    description: LoadBalancer contains the current status of the load-balancer,
+                      if one is present.
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+            required:
+            - clusterName
+            - status
+            type: object
+          type: array
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: federatedtypeconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: FederatedTypeConfig
+    listKind: FederatedTypeConfigList
+    plural: federatedtypeconfigs
+    shortNames:
+    - ftc
+    singular: federatedtypeconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "FederatedTypeConfig programs KubeFed to know about a single API
+        type - the \"target type\" - that a user wants to federate. For each target
+        type, there is a corresponding FederatedType that has the following fields:
+        \n - The \"template\" field specifies the basic definition of a federated
+        resource - The \"placement\" field specifies the placement information for
+        the federated   resource - The \"overrides\" field specifies how the target
+        resource should vary across   clusters."
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: FederatedTypeConfigSpec defines the desired state of FederatedTypeConfig.
+          properties:
+            federatedType:
+              description: Configuration for the federated type that defines (via
+                template, placement and overrides fields) how the target type should
+                appear in multiple cluster.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            propagation:
+              description: Whether or not propagation to member clusters should be
+                enabled.
+              type: string
+            statusCollection:
+              description: Whether or not Status object should be populated.
+              type: string
+            statusType:
+              description: Configuration for the status type that holds information
+                about which type holds the status of the federated resource. If not
+                provided, the group and version will default to those provided for
+                the federated type api resource.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+            targetType:
+              description: The configuration of the target type. If not set, the pluralName
+                and groupName fields will be set from the metadata.name of this resource.
+                The kind field must be set.
+              properties:
+                group:
+                  description: Group of the resource.
+                  type: string
+                kind:
+                  description: Camel-cased singular name of the resource (e.g. ConfigMap)
+                  type: string
+                pluralName:
+                  description: Lower-cased plural name of the resource (e.g. configmaps).  If
+                    not provided, it will be computed by lower-casing the kind and
+                    suffixing an 's'.
+                  type: string
+                scope:
+                  description: Scope of the resource.
+                  type: string
+                version:
+                  description: Version of the resource.
+                  type: string
+              required:
+              - kind
+              - pluralName
+              - scope
+              - version
+              type: object
+          required:
+          - federatedType
+          - propagation
+          - targetType
+          type: object
+        status:
+          description: FederatedTypeConfigStatus defines the observed state of FederatedTypeConfig
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the FederatedTypeConfig.
+              format: int64
+              type: integer
+            propagationController:
+              description: PropagationController tracks the status of the sync controller.
+              type: string
+            statusController:
+              description: StatusController tracks the status of the status controller.
+              type: string
+          required:
+          - observedGeneration
+          - propagationController
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: kubefedclusters.core.kubefed.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  - JSONPath: .status.conditions[?(@.type=='Ready')].status
+    name: ready
+    type: string
+  group: core.kubefed.io
+  names:
+    kind: KubeFedCluster
+    listKind: KubeFedClusterList
+    plural: kubefedclusters
+    singular: kubefedcluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: KubeFedCluster configures KubeFed to be aware of a Kubernetes cluster
+        and encapsulates the details necessary to communicate with the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedClusterSpec defines the desired state of KubeFedCluster
+          properties:
+            apiEndpoint:
+              description: The API endpoint of the member cluster. This can be a hostname,
+                hostname:port, IP or IP:port.
+              type: string
+            caBundle:
+              description: CABundle contains the certificate authority information.
+              format: byte
+              type: string
+            disabledTLSValidations:
+              description: DisabledTLSValidations defines a list of checks to ignore
+                when validating the TLS connection to the member cluster.  This can
+                be any of *, SubjectName, or ValidityPeriod. If * is specified, it
+                is expected to be the only option in list.
+              items:
+                type: string
+              type: array
+            secretRef:
+              description: Name of the secret containing the token required to access
+                the member cluster. The secret needs to exist in the same namespace
+                as the control plane and should have a "token" key.
+              properties:
+                name:
+                  description: Name of a secret within the enclosing namespace
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - apiEndpoint
+          - secretRef
+          type: object
+        status:
+          description: KubeFedClusterStatus contains information about the current
+            status of a cluster updated periodically by cluster controller.
+          properties:
+            conditions:
+              description: Conditions is an array of current cluster conditions.
+              items:
+                description: ClusterCondition describes current state of a cluster.
+                properties:
+                  lastProbeTime:
+                    description: Last time the condition was checked.
+                    format: date-time
+                    type: string
+                  lastTransitionTime:
+                    description: Last time the condition transit from one status to
+                      another.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Human readable message indicating details about last
+                      transition.
+                    type: string
+                  reason:
+                    description: (brief) reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of cluster condition, Ready or Offline.
+                    type: string
+                required:
+                - lastProbeTime
+                - status
+                - type
+                type: object
+              type: array
+            region:
+              description: Region is the name of the region in which all of the nodes
+                in the cluster exist.  e.g. 'us-east1'.
+              type: string
+            zones:
+              description: Zones are the names of availability zones in which the
+                nodes of the cluster exist, e.g. 'us-east1-a'.
+              items:
+                type: string
+              type: array
+          required:
+          - conditions
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: kubefedconfigs.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: KubeFedConfig
+    listKind: KubeFedConfigList
+    plural: kubefedconfigs
+    singular: kubefedconfig
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: KubeFedConfigSpec defines the desired state of KubeFedConfig
+          properties:
+            clusterHealthCheck:
+              properties:
+                failureThreshold:
+                  description: Minimum consecutive failures for the cluster health
+                    to be considered failed after having succeeded.
+                  format: int64
+                  type: integer
+                period:
+                  description: How often to monitor the cluster health.
+                  type: string
+                successThreshold:
+                  description: Minimum consecutive successes for the cluster health
+                    to be considered successful after having failed.
+                  format: int64
+                  type: integer
+                timeout:
+                  description: Duration after which the cluster health check times
+                    out.
+                  type: string
+              type: object
+            controllerDuration:
+              properties:
+                availableDelay:
+                  description: Time to wait before reconciling on a healthy cluster.
+                  type: string
+                unavailableDelay:
+                  description: Time to wait before giving up on an unhealthy cluster.
+                  type: string
+              type: object
+            featureGates:
+              items:
+                properties:
+                  configuration:
+                    type: string
+                  name:
+                    type: string
+                required:
+                - configuration
+                - name
+                type: object
+              type: array
+            leaderElect:
+              properties:
+                leaseDuration:
+                  description: The duration that non-leader candidates will wait after
+                    observing a leadership renewal until attempting to acquire leadership
+                    of a led but unrenewed leader slot. This is effectively the maximum
+                    duration that a leader can be stopped before it is replaced by
+                    another candidate. This is only applicable if leader election
+                    is enabled.
+                  type: string
+                renewDeadline:
+                  description: The interval between attempts by the acting master
+                    to renew a leadership slot before it stops leading. This must
+                    be less than or equal to the lease duration. This is only applicable
+                    if leader election is enabled.
+                  type: string
+                resourceLock:
+                  description: The type of resource object that is used for locking
+                    during leader election. Supported options are `configmaps` (default)
+                    and `endpoints`.
+                  type: string
+                retryPeriod:
+                  description: The duration the clients should wait between attempting
+                    acquisition and renewal of a leadership. This is only applicable
+                    if leader election is enabled.
+                  type: string
+              type: object
+            scope:
+              description: The scope of the KubeFed control plane should be either
+                `Namespaced` or `Cluster`. `Namespaced` indicates that the KubeFed
+                namespace will be the only target of the control plane.
+              type: string
+            syncController:
+              properties:
+                adoptResources:
+                  description: Whether to adopt pre-existing resources in member clusters.
+                    Defaults to "Enabled".
+                  type: string
+              type: object
+          required:
+          - scope
+          type: object
+      required:
+      - spec
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: propagatedversions.core.kubefed.io
+spec:
+  group: core.kubefed.io
+  names:
+    kind: PropagatedVersion
+    listKind: PropagatedVersionList
+    plural: propagatedversions
+    singular: propagatedversion
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PropagatedVersion holds version information about the state propagated
+        from KubeFed APIs (configured by FederatedTypeConfig resources) to member
+        clusters. The name of a PropagatedVersion encodes the kind and name of the
+        resource it stores information for (i.e. <lower-case kind>-<resource name>).
+        If a target resource has a populated metadata.Generation field, the generation
+        will be stored with a prefix of `gen:` as the version for the cluster.  If
+        metadata.Generation is not available, metadata.ResourceVersion will be stored
+        with a prefix of `rv:` as the version for the cluster.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        status:
+          description: PropagatedVersionStatus defines the observed state of PropagatedVersion
+          properties:
+            clusterVersions:
+              description: The last versions produced in each cluster for this resource.
+              items:
+                properties:
+                  clusterName:
+                    description: The name of the cluster the version is for.
+                    type: string
+                  version:
+                    description: The last version produced for the resource by a KubeFed
+                      operation.
+                    type: string
+                required:
+                - clusterName
+                - version
+                type: object
+              type: array
+            overridesVersion:
+              description: The observed version of the overrides for this resource.
+              type: string
+            templateVersion:
+              description: The observed version of the template for this resource.
+              type: string
+          required:
+          - overridesVersion
+          - templateVersion
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: dnsendpoints.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: DNSEndpoint
+    listKind: DNSEndpointList
+    plural: dnsendpoints
+    singular: dnsendpoint
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DNSEndpoint is the CRD wrapper for Endpoint which is designed to
+        act as a source of truth for external-dns.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DNSEndpointSpec defines the desired state of DNSEndpoint
+          properties:
+            endpoints:
+              items:
+                description: Endpoint is a high-level association between a service
+                  and an IP.
+                properties:
+                  dnsName:
+                    description: The FQDN of the DNS record.
+                    type: string
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels stores labels defined for the Endpoint.
+                    type: object
+                  recordTTL:
+                    description: TTL for the record in seconds.
+                    format: int64
+                    type: integer
+                  recordType:
+                    description: RecordType type of record, e.g. CNAME, A, SRV, TXT
+                      etc.
+                    type: string
+                  targets:
+                    description: The targets that the DNS record points to.
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+          type: object
+        status:
+          description: DNSEndpointStatus defines the observed state of DNSEndpoint
+          properties:
+            observedGeneration:
+              description: ObservedGeneration is the generation as observed by the
+                controller consuming the DNSEndpoint.
+              format: int64
+              type: integer
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: domains.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: Domain
+    listKind: DomainList
+    plural: domains
+    singular: domain
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        domain:
+          description: Domain is the DNS zone associated with the KubeFed control
+            plane
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        nameServer:
+          description: NameServer is the authoritative DNS name server for the KubeFed
+            domain
+          type: string
+      required:
+      - domain
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: ingressdnsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: IngressDNSRecord
+    listKind: IngressDNSRecordList
+    plural: ingressdnsrecords
+    singular: ingressdnsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: IngressDNSRecordSpec defines the desired state of IngressDNSRecord
+          properties:
+            hosts:
+              description: Host from the IngressRule in Cluster Ingress Spec
+              items:
+                type: string
+              type: array
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for the Ingress, if omitted a default would be used
+              format: int64
+              type: integer
+          type: object
+        status:
+          description: IngressDNSRecordStatus defines the observed state of IngressDNSRecord
+          properties:
+            dns:
+              description: Array of Ingress Controller LoadBalancers
+              items:
+                description: ClusterIngressDNS defines the observed status of Ingress
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding ingress controller
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: servicednsrecords.multiclusterdns.kubefed.io
+spec:
+  group: multiclusterdns.kubefed.io
+  names:
+    kind: ServiceDNSRecord
+    listKind: ServiceDNSRecordList
+    plural: servicednsrecords
+    singular: servicednsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: "ServiceDNSRecord defines a scheme of DNS name and subdomains that
+        should be programmed with endpoint information about a Service deployed in
+        multiple Kubernetes clusters. ServiceDNSRecord is name-associated with the
+        Services it programs endpoint information for, meaning that a ServiceDNSRecord
+        expresses the intent to program DNS with information about endpoints for the
+        Kubernetes Service resources with the same name and namespace in different
+        clusters. \n For the example, given the following values: \n metadata.name:
+        test-service metadata.namespace: test-namespace spec.federationName: test-federation
+        \n the following set of DNS names will be programmed: \n Global Level: test-service.test-namespace.test-federation.svc.<federation-domain>
+        Region Level: test-service.test-namespace.test-federation.svc.(status.DNS[*].region).<federation-domain>
+        Zone Level  : test-service.test-namespace.test-federation.svc.(status.DNS[*].zone).(status.DNS[*].region).<federation-domain>
+        \n Optionally, when DNSPrefix is specified, another DNS name will be programmed
+        which would be a CNAME record pointing to DNS name at global level as below:
+        <dns-prefix>.<federation-domain> --> test-service.test-namespace.test-federation.svc.<federation-domain>"
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ServiceDNSRecordSpec defines the desired state of ServiceDNSRecord.
+          properties:
+            allowServiceWithoutEndpoints:
+              description: AllowServiceWithoutEndpoints allows DNS records to be written
+                for Service shards without endpoints
+              type: boolean
+            dnsPrefix:
+              description: DNSPrefix when specified, an additional DNS record would
+                be created with <DNSPrefix>.<KubeFedDomain>
+              type: string
+            domainRef:
+              description: DomainRef is the name of the domain object to which the
+                corresponding federated service belongs
+              type: string
+            externalName:
+              description: ExternalName when specified, replaces the service name
+                portion of a resource record with the value of ExternalName.
+              type: string
+            recordTTL:
+              description: RecordTTL is the TTL in seconds for DNS records created
+                for this Service, if omitted a default would be used
+              format: int64
+              type: integer
+          required:
+          - domainRef
+          type: object
+        status:
+          description: ServiceDNSRecordStatus defines the observed state of ServiceDNSRecord.
+          properties:
+            dns:
+              items:
+                description: ClusterDNS defines the observed status of LoadBalancer
+                  within a cluster.
+                properties:
+                  cluster:
+                    description: Cluster name
+                    type: string
+                  loadBalancer:
+                    description: LoadBalancer for the corresponding service
+                    properties:
+                      ingress:
+                        description: Ingress is a list containing ingress points for
+                          the load-balancer. Traffic intended for the service should
+                          be sent to these ingress points.
+                        items:
+                          description: 'LoadBalancerIngress represents the status
+                            of a load-balancer ingress point: traffic intended for
+                            the service should be sent to an ingress point.'
+                          properties:
+                            hostname:
+                              description: Hostname is set for load-balancer ingress
+                                points that are DNS based (typically AWS load-balancers)
+                              type: string
+                            ip:
+                              description: IP is set for load-balancer ingress points
+                                that are IP based (typically GCE or OpenStack load-balancers)
+                              type: string
+                          type: object
+                        type: array
+                    type: object
+                  region:
+                    description: Region to which the cluster belongs
+                    type: string
+                  zones:
+                    description: Zones to which the cluster belongs
+                    items:
+                      type: string
+                    type: array
+                type: object
+              type: array
+            domain:
+              description: Domain is the DNS domain of the KubeFed control plane as
+                in Domain API
+              type: string
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: replicaschedulingpreferences.scheduling.kubefed.io
+spec:
+  group: scheduling.kubefed.io
+  names:
+    kind: ReplicaSchedulingPreference
+    listKind: ReplicaSchedulingPreferenceList
+    plural: replicaschedulingpreferences
+    singular: replicaschedulingpreference
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ReplicaSchedulingPreferenceSpec defines the desired state of
+            ReplicaSchedulingPreference
+          properties:
+            clusters:
+              additionalProperties:
+                description: Preferences regarding number of replicas assigned to
+                  a cluster workload object (dep, rs, ..) within a federated workload
+                  object.
+                properties:
+                  maxReplicas:
+                    description: Maximum number of replicas that should be assigned
+                      to this cluster workload object. Unbounded if no value provided
+                      (default).
+                    format: int64
+                    type: integer
+                  minReplicas:
+                    description: Minimum number of replicas that should be assigned
+                      to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                  weight:
+                    description: A number expressing the preference to put an additional
+                      replica to this cluster workload object. 0 by default.
+                    format: int64
+                    type: integer
+                type: object
+              description: A mapping between cluster names and preferences regarding
+                a local workload object (dep, rs, .. ) in these clusters. "*" (if
+                provided) applies to all clusters if an explicit mapping is not provided.
+                If omitted, clusters without explicit preferences should not have
+                any replicas scheduled.
+              type: object
+            rebalance:
+              description: If set to true then already scheduled and running replicas
+                may be moved to other clusters in order to match current state to
+                the specified preferences. Otherwise, if set to false, up and running
+                replicas will not be moved.
+              type: boolean
+            targetKind:
+              description: TODO (@irfanurrehman); upgrade this to label selector only
+                if need be. The idea of this API is to have a a set of preferences
+                which can be used for a target FederatedDeployment or FederatedReplicaset.
+                Although the set of preferences in question can be applied to multiple
+                target objects using label selectors, but there are no clear advantages
+                of doing that as of now. To keep the implementation and usage simple,
+                matching ns/name of RSP resource to the target resource is sufficient
+                and only additional information needed in RSP resource is a target
+                kind (FederatedDeployment or FederatedReplicaset).
+              type: string
+            totalReplicas:
+              description: Total number of pods desired across federated clusters.
+                Replicas specified in the spec for target deployment template or replicaset
+                template will be discarded/overridden when scheduling preferences
+                are specified.
+              format: int32
+              type: integer
+          required:
+          - targetKind
+          - totalReplicas
+          type: object
+        status:
+          description: ReplicaSchedulingPreferenceStatus defines the observed state
+            of ReplicaSchedulingPreference
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/kubefed-crds/crds/kubefed-crds.yaml
+++ b/charts/kubefed-crds/crds/kubefed-crds.yaml
@@ -1,0 +1,1297 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedclusterroles.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedClusterRole
+    plural: federatedclusterroles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedconfigmaps.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedConfigMap
+    plural: federatedconfigmaps
+    shortNames:
+    - fcm
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federateddeployments.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedDeployment
+    plural: federateddeployments
+    shortNames:
+    - fdeploy
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedingresses.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedIngress
+    plural: federatedingresses
+    shortNames:
+    - fing
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedjobs.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedJob
+    plural: federatedjobs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatednamespaces.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedNamespace
+    plural: federatednamespaces
+    shortNames:
+    - fns
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedreplicasets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedReplicaSet
+    plural: federatedreplicasets
+    shortNames:
+    - frs
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            retainReplicas:
+              type: boolean
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedsecrets.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedSecret
+    plural: federatedsecrets
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedserviceaccounts.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedServiceAccount
+    plural: federatedserviceaccounts
+    shortNames:
+    - fsa
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: federatedservices.types.kubefed.io
+spec:
+  group: types.kubefed.io
+  names:
+    kind: FederatedService
+    plural: federatedservices
+    shortNames:
+    - fsvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            overrides:
+              items:
+                properties:
+                  clusterName:
+                    type: string
+                  clusterOverrides:
+                    items:
+                      properties:
+                        op:
+                          pattern: ^(add|remove|replace)?$
+                          type: string
+                        path:
+                          type: string
+                        value:
+                          anyOf:
+                          - type: string
+                          - type: integer
+                          - type: boolean
+                          - type: object
+                          - type: array
+                      required:
+                      - path
+                      type: object
+                    type: array
+                type: object
+              type: array
+            placement:
+              properties:
+                clusterSelector:
+                  properties:
+                    matchExpressions:
+                      items:
+                        properties:
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          values:
+                            items:
+                              type: string
+                            type: array
+                        required:
+                        - key
+                        - operator
+                        type: object
+                      type: array
+                    matchLabels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                  type: object
+                clusters:
+                  items:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            template:
+              type: object
+          type: object
+        status:
+          properties:
+            clusters:
+              items:
+                properties:
+                  name:
+                    type: string
+                  status:
+                    type: string
+                required:
+                - name
+                type: object
+              type: array
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    format: date-time
+                    type: string
+                  reason:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            observedGeneration:
+              format: int64
+              type: integer
+          type: object
+      required:
+      - spec
+  version: v1beta1

--- a/charts/kubefed/README.md
+++ b/charts/kubefed/README.md
@@ -168,15 +168,17 @@ Install the chart and specify the version to install with the
 ```bash
 helm install kubefed-crds kubefed-charts/kubefed-crds --version=<x.x.x> --namespace kube-federation-system
 ```
-> this will yield an error "Error: no objects visited" that you can safely ignore
-> see: https://github.com/helm/helm/issues/4670
+This will yield an error "Error: no objects visited" that you can safely ignore
+
+see: https://github.com/helm/helm/issues/4670
 
 
 ```bash
 helm install kubefed kubefed-charts/kubefed --version=<x.x.x> --namespace kube-federation-system
 ```
-> You will see info messages "manifest_sorter.go:192: info: skipping unknown hook: "crd-install" "
-> crd-install hook have been deprecated in favour of crds folders. You can ignore these messages.
+You will see info messages "manifest_sorter.go:192: info: skipping unknown hook: "crd-install" "
+
+crd-install hook have been deprecated in favour of crds folders. You can ignore these messages.
 
 ### Uninstalling the Chart
 
@@ -206,8 +208,9 @@ you will have to delete kubefed-crd as well
 ```bash
 $ helm delete kubefed-crds --namespace kube-federation-system
 ```
-> this will yield an error "Error: uninstallation completed with 1 error(s): object not found, skipping delete" that you can safely ignore
-> see: https://github.com/helm/helm/issues/4670
+this will yield an error "Error: uninstallation completed with 1 error(s): object not found, skipping delete" that you can safely ignore
+
+see: https://github.com/helm/helm/issues/4670
 
 The command above removes all the Kubernetes components associated with the chart
 and deletes the release.


### PR DESCRIPTION
**What this PR does / why we need it**:
With the release of Helm3, having kubefed working seamlessly with that version will encourage adoption of this project.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
About the XXL size:
2467 new lines are due to the copy of charts/kubefed/templates/crds.yaml and charts/kubefed/charts/controllermanager/crds.yaml to charts/kubefed-crds/crds
Only change in them is the removal of first and last line, crds does not support templating in Helm3.

Chosen solution:
The approach here is the "Separate Charts" recommended by Helm v3 documentation
https://helm.sh/docs/topics/chart_best_practices/custom_resource_definitions/

Please note:
Some minor warnings seems not avoidable at the moment but the end result is working.
Documentation has been updated accordingly.


