### PR TITLE
chore: serve metrics

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -25,6 +25,9 @@ spec:
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: controller-manager
+        ports:
+        - containerPort: 9090
+          name: metrics
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kubefed/charts/controllermanager/templates/service.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/service.yaml
@@ -9,3 +9,19 @@ spec:
   ports:
   - port: 443
     targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+annotations:
+  prometheus.io/port: "9090"
+  prometheus.io/scheme: https
+  prometheus.io/scrape: "true"
+metadata:
+  name: kubefed-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    kubefed-control-plane: "controller-manager"
+  ports:
+  - port: metrics
+    targetPort: 9090

--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	apiextv1b1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +39,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"sigs.k8s.io/kubefed/cmd/controller-manager/app/leaderelection"
 	"sigs.k8s.io/kubefed/cmd/controller-manager/app/options"
@@ -55,8 +57,13 @@ import (
 	"sigs.k8s.io/kubefed/pkg/version"
 )
 
+const (
+	metricsDefaultBindAddress = ":9090"
+	healthzDefaultBindAddress = ":8080"
+)
+
 var (
-	kubeconfig, kubeFedConfig, masterURL string
+	kubeconfig, kubeFedConfig, masterURL, metricsAddr, healthzAddr string
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
@@ -87,7 +94,9 @@ member clusters and do the necessary reconciliation`,
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
 
 	opts.AddFlags(cmd.Flags())
-	cmd.Flags().BoolVar(&verFlag, "version", false, "Prints the Version info of controller-manager")
+	cmd.Flags().StringVar(&healthzAddr, "healthz-addr", healthzDefaultBindAddress, "The address the healthz endpoint binds to.")
+	cmd.Flags().StringVar(&metricsAddr, "metrics-addr", metricsDefaultBindAddress, "The address the metric endpoint binds to.")
+	cmd.Flags().BoolVar(&verFlag, "version", false, "Prints the Version info of controller-manager.")
 	cmd.Flags().StringVar(&kubeFedConfig, "kubefed-config", "", "Path to a KubeFedConfig yaml file. Test only.")
 	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	cmd.Flags().StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
@@ -100,8 +109,8 @@ func Run(opts *options.Options, stopChan <-chan struct{}) error {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	// TODO: Make healthz endpoint configurable
-	go serveHealthz(":8080")
+	go serveHealthz(healthzAddr)
+	go serveMetrics(metricsAddr, stopChan)
 
 	var err error
 	opts.Config.KubeConfig, err = clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
@@ -394,4 +403,38 @@ func serveHealthz(address string) {
 	})
 
 	klog.Fatal(http.ListenAndServe(address, nil))
+}
+
+func serveMetrics(address string, stop <-chan struct{}) {
+	listener, err := metrics.NewListener(address)
+	if err != nil {
+		klog.Errorf("error creating the new metrics listener")
+		klog.Fatal(err)
+	}
+	var metricsPath = "/metrics"
+	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+	mux := http.NewServeMux()
+	mux.Handle(metricsPath, handler)
+	server := http.Server{
+		Handler: mux,
+	}
+	// Run the server
+	go func() {
+		klog.V(1).Infof("starting metrics server path %s", metricsPath)
+		if err := server.Serve(listener); err != nil && err != http.ErrServerClosed {
+			klog.Errorf("error starting the mertrics server")
+			klog.Fatal(err)
+		}
+	}()
+
+	// Shutdown the server when stop is closed
+	select {
+	case <-stop:
+		if err := server.Shutdown(context.Background()); err != nil {
+			klog.Errorf("error shutting down the server")
+			klog.Fatal(err)
+		}
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openshift/generic-admission-server v1.14.0
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Serve metrics as part of kubefed. This PR aims to start exposing metrics and adding kubefed custom ones. 

Drawback: these controllers are not using the controller-runtime so some of the metrics aren't available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
