### PR TITLE
chore: serve controller default metrics

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -25,6 +25,9 @@ spec:
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: controller-manager
+        ports:
+        - containerPort: 9090
+          name: metrics
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/kubefed/charts/controllermanager/templates/service.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/service.yaml
@@ -9,3 +9,20 @@ spec:
   ports:
   - port: 443
     targetPort: 8443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubefed-controller-manager-metrics-service
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/port: "9090"
+    prometheus.io/scheme: http
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    kubefed-control-plane: "controller-manager"
+  ports:
+  - name: metrics
+    port: 9090
+    targetPort: metrics

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/openshift/generic-admission-server v1.14.0
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
+	github.com/prometheus/client_golang v1.0.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
+github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR exposes default controller metrics and makes both `healthz-addr` and `metrics-addr` configurable via flags.

```
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.001"} 33
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.002"} 156
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.004"} 606
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.008"} 1779
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.016"} 2057
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.032"} 2061
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.064"} 2129
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.128"} 2387
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.256"} 2388
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="0.512"} 2388
rest_client_request_latency_seconds_bucket{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET",le="+Inf"} 2388
rest_client_request_latency_seconds_sum{url="https://10.0.0.1:443/%7Bprefix%7D",verb="GET"} 34.46997236000008
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

In addition to this PR, I have prepared another work which adds kubefed custom metrics to certain actions which will give us a better view of future bottleneck of scalability issues.

