### PR TITLE
Release script improvements

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -56,7 +56,7 @@ prereqs:
 
 Creating a KubeFed release involves the following steps:
 
-1. Locally create an annotated tag in the format `v[0-9]+.[0-9]+.[0-9]+`
+1. Locally create an annotated tag in the format `v[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?`
    - `git tag -a <tag> -m "Creating release tag <tag>"`
    - An annotated tag is required to ensure that the `kubefedctl` and
      `controller-manager` binaries are versioned correctly.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,7 +57,7 @@ prereqs:
 Creating a KubeFed release involves the following steps:
 
 1. Locally create an annotated tag in the format `v[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?`
-   - `git tag -a <tag> -m "Creating release tag <tag>"`
+   - `git tag -s -a <tag> -m "Creating release tag <tag>"`
    - An annotated tag is required to ensure that the `kubefedctl` and
      `controller-manager` binaries are versioned correctly.
    - At the time of writing, it is not possible to create an

--- a/scripts/build-release-artifacts.sh
+++ b/scripts/build-release-artifacts.sh
@@ -27,7 +27,7 @@ source "$(dirname "${BASH_SOURCE}")/util.sh"
 
 RELEASE_TAG="${1-}"
 if [[ ! "${RELEASE_TAG}" =~ ${RELEASE_TAG_REGEX} ]]; then
-  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?>"
+  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?>"
   exit 1
 fi
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -46,7 +46,7 @@ function build-release-artifacts() {
 function create-and-push-tag() {
   # Use the upstream git remote convention name used by hub.
 
-  if git ls-remote --tags "${GITHUB_REMOTE_UPSTREAM_NAME}" refs/tags/"${RELEASE_TAG}" &> /dev/null; then
+  if git ls-remote --tags "${GITHUB_REMOTE_UPSTREAM_NAME}" refs/tags/"${RELEASE_TAG}" | grep -E refs/tags/"${RELEASE_TAG}" &> /dev/null; then
     echo "git tag ${RELEASE_TAG} already exists in ${GITHUB_REMOTE_UPSTREAM_NAME} remote. Continuing..."
     return 0
   fi

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -142,7 +142,7 @@ function update-changelog() {
 }
 
 if [[ ! "${RELEASE_TAG}" =~ ${RELEASE_TAG_REGEX} ]]; then
-  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?>"
+  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?>"
   exit 1
 fi
 

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -127,8 +127,8 @@ function verify-continuous-integration() {
 }
 
 function quay-image-status() {
-  local quayImagesApi="https://quay.io/api/v1/repository/${QUAY_REPO}/image/"
-  curl -s ${quayImagesApi} | grep "${RELEASE_TAG}" &> /dev/null
+  local quayImagesApi="https://quay.io/api/v1/repository/${QUAY_REPO}/tag/${RELEASE_TAG}/images"
+  curl -fsSL ${quayImagesApi} &> /dev/null
 }
 
 function verify-container-image() {

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -56,7 +56,7 @@ function create-and-push-tag() {
 
   # This creates an annotated tag required to ensure that the KubeFed binaries
   # are versioned correctly.
-  git tag -a "${RELEASE_TAG}" "${GITHUB_REMOTE_UPSTREAM_NAME}/master" -m "Creating release tag ${RELEASE_TAG}"
+  git tag -s -a "${RELEASE_TAG}" "${GITHUB_REMOTE_UPSTREAM_NAME}/master" -m "Creating release tag ${RELEASE_TAG}"
   git push "${GITHUB_REMOTE_UPSTREAM_NAME}" "${RELEASE_TAG}"
 }
 
@@ -152,7 +152,7 @@ verify-command-installed
 util::log "Building release artifacts first to make sure build succeeds"
 build-release-artifacts
 
-util::log "Creating local git annotated tag and pushing tag to kick off build process"
+util::log "Creating local git signed and annotated tag and pushing tag to kick off build process"
 create-and-push-tag
 
 util::log "Verifying image builds and completes successfully in Travis. This can take a while (~1 hour)"

--- a/scripts/create-gh-release.sh
+++ b/scripts/create-gh-release.sh
@@ -109,7 +109,7 @@ function create-release-pr() {
 }
 
 if [[ ! "${RELEASE_TAG}" =~ ${RELEASE_TAG_REGEX} ]]; then
-  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-rc[0-9]+)?>"
+  >&2 echo "usage: $0 <release tag of the form v[0-9]+.[0-9]+.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?>"
   exit 1
 fi
 

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -21,7 +21,7 @@
 #
 # RELEASE_TAG_REGEX contains the regular expression used to validate a semantic
 # version.
-export RELEASE_TAG_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$"
+export RELEASE_TAG_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.?[0-9]+)?$"
 
 
 # Utility Functions


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

=**What this PR does / why we need it**:
Some tweaks to the release scripts to:

- Support alpha, beta, rc version suffixes
- Fix up git tag check
- Fix up check for image available from quay.io

**Special notes for your reviewer**:
Used in latest release, v0.2.0-alpha.1