### PR TITLE
FIX: namespaced condition for api resource

### DIFF
--- a/pkg/kubefedctl/federate/federate.go
+++ b/pkg/kubefedctl/federate/federate.go
@@ -247,7 +247,7 @@ func FederateResources(resources []*unstructured.Unstructured) ([]*unstructured.
 			Version:      gvk.Version,
 			Kind:         gvk.Kind,
 		}
-		apiResource.Namespaced = targetResource.GetNamespace() == ""
+		apiResource.Namespaced = targetResource.GetNamespace() != ""
 
 		qualifiedName := ctlutil.NewQualifiedName(targetResource)
 		typeConfig := enable.GenerateTypeConfigForTarget(apiResource, enable.NewEnableTypeDirective())

--- a/pkg/kubefedctl/federate/federate_test.go
+++ b/pkg/kubefedctl/federate/federate_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package federate_test
 
 import (

--- a/pkg/kubefedctl/federate/federate_test.go
+++ b/pkg/kubefedctl/federate/federate_test.go
@@ -1,0 +1,65 @@
+package federate_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/kubefed/pkg/kubefedctl/federate"
+)
+
+func TestFederateResources(t *testing.T) {
+	var resource = &unstructured.Unstructured{}
+	resource.Object = map[string]interface{}{
+		"name": "name",
+		"spec": map[string]interface{}{
+			"replicas": "2",
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+			"template": map[string]interface{}{
+				"labels": map[string]interface{}{
+					"foo": "bar",
+				},
+			},
+		},
+	}
+	resource.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "apps",
+		Kind:    "Deployment",
+		Version: "v1",
+	})
+
+	t.Run("TestNonNameSpacedDeployment", func(t *testing.T) {
+		federatedResources, err := federate.FederateResources([]*unstructured.Unstructured{resource})
+		assert.NoError(t, err, "Should not expect any errorr")
+		assert.Len(t, federatedResources, 1, "Should return a federated resource")
+
+		federatedResource := federatedResources[0]
+
+		assert.Empty(t, federatedResource.GetNamespace(), "Should not return a namespaces if not set")
+		assert.Equal(t, "FederatedDeployment", federatedResource.GetKind(), "Federated Resources should return a federated crd")
+		assert.Equal(t, "types.kubefed.io/v1beta1", federatedResource.GetAPIVersion(), "federated resourece should return correct api-version")
+		federatedSpec := federatedResource.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+		assert.Equal(t, resource.Object["spec"], federatedSpec)
+	})
+
+	t.Run("TestNameSpacedDeployment", func(t *testing.T) {
+		testNS := "testNS"
+		resource.SetNamespace(testNS)
+		federatedResources, err := federate.FederateResources([]*unstructured.Unstructured{resource})
+		assert.NoError(t, err, "Should not expect any errorr")
+		assert.Len(t, federatedResources, 1, "Should return a federated resource")
+
+		federatedResource := federatedResources[0]
+		assert.Equal(t, testNS, federatedResource.GetNamespace(), "A namespaces should be set and match orignal resource")
+		assert.Equal(t, "FederatedDeployment", federatedResource.GetKind(), "Federated Resources should return a federated crd")
+		assert.Equal(t, "types.kubefed.io/v1beta1", federatedResource.GetAPIVersion(), "federated resourece should return correct api-version")
+		federatedSpec := federatedResource.Object["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"]
+		assert.Equal(t, resource.Object["spec"], federatedSpec)
+	})
+
+}


### PR DESCRIPTION
The current code checks if the api resource is namespaced or not by a faulty condition,

	`apiResource.Namespaced = targetResource.GetNamespace() == ""`

If the input kubernetes api-resource has a namespace, the above condition makes the federatedapi-resource not namespaced, due to which the namespaces are not populated in the federatedapi-resource.

Changing the above condition to

	`apiResource.Namespaced = targetResource.GetNamespace() != ""`

makes the federated-api-resource as namespaced and sets the namespace as well.

Read more on [issue#1181](https://github.com/kubernetes-sigs/kubefed/issues/1181)

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
https://github.com/kubernetes-sigs/kubefed/issues/1181
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/kubefed/issues/1181
**Special notes for your reviewer**: