### PR TITLE
Bump Helm version to 2.16.3 in download-binaries script

### DIFF
--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -50,7 +50,7 @@ curl "${curl_args}O" "${kb_url}" \
   && tar xzfP "${kb_tgz}" -C "${dest_dir}" --strip-components=2 \
   && rm "${kb_tgz}"
 
-helm_version="2.14.0"
+helm_version="2.16.3"
 helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
 helm_url="https://storage.googleapis.com/kubernetes-helm/$helm_tgz"
 curl "${curl_args}O" "${helm_url}" \


### PR DESCRIPTION
The current version installed in the script (2.14.0) produces the following error when executing `helm init`:  **_Error: error installing: the server could not find the requested resource_**. This is due to an incompatibility with clusters with versions 1.16.0+, found on https://github.com/helm/helm/issues/6374.
To fix this, the Helm version is bumped to `2.16.3`. 