### PR TITLE
docs: add missing devel flag to helm commands (#1203)

### DIFF
--- a/charts/kubefed/README.md
+++ b/charts/kubefed/README.md
@@ -71,13 +71,13 @@ kubefed-charts   https://raw.githubusercontent.com/kubernetes-sigs/kubefed/maste
 
 With the repo added, available charts and versions can be viewed.
 ```bash
-$ helm search kubefed
+$ helm search kubefed --devel
 ```
 
 Install the chart and specify the version to install with the
 `--version` argument. Replace `<x.x.x>` with your desired version.
 ```bash
-$ helm install kubefed-charts/kubefed --name kubefed --version=<x.x.x> --namespace kube-federation-system
+$ helm install kubefed-charts/kubefed --name kubefed --version=<x.x.x> --namespace kube-federation-system --devel
 ```
 
 **NOTE:** For **namespace-scoped deployments** (configured with the `--set
@@ -157,5 +157,5 @@ Alternatively, a YAML file that specifies the values for the parameters can be
 provided while installing the chart. For example:
 
 ```bash
-$ helm install kubefed-charts/kubefed --name kubefed --namespace kube-federation-system --values values.yaml
+$ helm install kubefed-charts/kubefed --name kubefed --namespace kube-federation-system --values values.yaml --devel
 ```


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Helm search and install needs the devel flag, as currently the latest version of the chart is still a development release. However, this is not included in the documentation. As such, following the documentation will not lead to the desired effect.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1203

**Special notes for your reviewer**: 