### PR TITLE
fix: enable command for crd resources

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -111,11 +111,12 @@ See the [Cluster Registration documentation](./cluster-registration.md) for more
 You can enable federation of any Kubernetes API type (including CRDs) by using the
 `kubefedctl` command as follows.
 
-**NOTE:** Federation of a CRD requires that the CRD be installed on all member clusters.  If
-the CRD is not installed on a member cluster, propagation to that cluster will fail.
+**NOTE:** Federation of a CRD requires that the CRD Kubernetes type (`customresourcedefinitions`) to be enabled, to then 
+federate any custom CRD on the member clusters. If the CRD Kubernetes type is not enabled and its Federated equivalent CRD is not federated, the propagation to that cluster will fail.
 
 ```bash
-kubefedctl enable <target kubernetes API type>
+kubefedctl enable customresourcedefinitions
+kubefedctl federate crd <target kubernetes API type>  # <target kubernetes API type> = mytype.mygroup.mydomain.io
 ```
 
 The `<target kubernetes API type>` can be any of the following

--- a/pkg/kubefedctl/enable/schema.go
+++ b/pkg/kubefedctl/enable/schema.go
@@ -189,7 +189,8 @@ func (v *jsonSchemaVistor) VisitReference(r proto.Reference) {
 	// Short-circuit the recursive definition of JSONSchemaProps (used for CRD validation)
 	//
 	// TODO(marun) Implement proper support for recursive schema
-	if r.Reference() == "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps" {
+	if r.Reference() == "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps" ||
+		r.Reference() == "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps" {
 		v.collect(apiextv1b1.JSONSchemaProps{Type: "object"})
 		return
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`kubefedctl enable crd` command was throwing a panic as reported in https://github.com/kubernetes-sigs/kubefed/issues/1206. It is related to what @marun  did here https://github.com/kubernetes-sigs/kubefed/pull/470. I might need a bit more of context to address the TODO comment.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/kubernetes-sigs/kubefed/issues/1206
**Special notes for your reviewer**:


```
kubefedctl enable crd
customresourcedefinition.apiextensions.k8s.io/federatedcustomresourcedefinitions.types.kubefed.io created
federatedtypeconfig.core.kubefed.io/customresourcedefinitions.apiextensions.k8s.io updated in namespace kommander

```
I also tested to enable one of our custom resource definitions:
```
$ kubefedctl federate crd addons.kubeaddons.mesosphere.io

$ kubectl get federatedcustomresourcedefinitions 
NAME                              AGE
addons.kubeaddons.mesosphere.io   51s
```