### PR TITLE
Use k8s-vendored extension as replacement of openapi-standard arbitrary type 

### DIFF
--- a/charts/kubefed/templates/crds.yaml
+++ b/charts/kubefed/templates/crds.yaml
@@ -39,12 +39,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -128,6 +123,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -171,12 +167,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -260,6 +251,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -303,12 +295,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -394,6 +381,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -437,12 +425,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -526,6 +509,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -567,12 +551,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -656,6 +635,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -699,12 +679,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -788,6 +763,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -831,12 +807,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -922,6 +893,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -963,12 +935,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1052,6 +1019,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1095,12 +1063,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1184,6 +1147,7 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -1227,12 +1191,7 @@ spec:
                         path:
                           type: string
                         value:
-                          anyOf:
-                          - type: string
-                          - type: integer
-                          - type: boolean
-                          - type: object
-                          - type: array
+                          x-kubernetes-preserve-unknown-fields: true
                       required:
                       - path
                       type: object
@@ -1316,5 +1275,6 @@ spec:
           type: object
       required:
       - spec
+      type: object
   version: v1beta1
 {{ end }}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a
 	k8s.io/kubectl v0.17.3
+	k8s.io/utils v0.0.0-20191114184206-e782cd3c129f
 	sigs.k8s.io/controller-runtime v0.5.0
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -18,6 +18,7 @@ package enable
 
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 )
@@ -119,23 +120,7 @@ func federatedTypeValidationSchema(templateSchema map[string]v1beta1.JSONSchemaP
 												// precludes up-front validation.  Errors in
 												// the definition of override values will need to
 												// be caught during propagation.
-												AnyOf: []v1beta1.JSONSchemaProps{
-													{
-														Type: "string",
-													},
-													{
-														Type: "integer",
-													},
-													{
-														Type: "boolean",
-													},
-													{
-														Type: "object",
-													},
-													{
-														Type: "array",
-													},
-												},
+												XPreserveUnknownFields: pointer.BoolPtr(true),
 											},
 										},
 										Required: []string{
@@ -175,6 +160,7 @@ func federatedTypeValidationSchema(templateSchema map[string]v1beta1.JSONSchemaP
 func ValidationSchema(specProps v1beta1.JSONSchemaProps) *v1beta1.CustomResourceValidation {
 	return &v1beta1.CustomResourceValidation{
 		OpenAPIV3Schema: &v1beta1.JSONSchemaProps{
+			Type: "object",
 			Properties: map[string]v1beta1.JSONSchemaProps{
 				"apiVersion": {
 					Type: "string",


### PR DESCRIPTION
kubernetes' CRD only support a subset of openapi specification which is (at least currently) excluding the openapi's standard form of expressing arbitrary types. we're supposed to use `x-kubernetes-preserve-unknown-fields` extension as a replacement otherwise the generated CRD from typeconfigs will always be falling back to structureless CRD which basically leaves the CRs unprotected by openapi's schema validation:

```
  - lastTransitionTime: "2020-04-08T12:19:52Z"
    message: '[spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].anyOf[0].type:
      Forbidden: must be empty to be structural, spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].anyOf[1].type:
      Forbidden: must be empty to be structural, spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].anyOf[2].type:
      Forbidden: must be empty to be structural, spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].anyOf[3].type:
      Forbidden: must be empty to be structural, spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].anyOf[4].type:
      Forbidden: must be empty to be structural, spec.versions[0].schema.openAPIV3Schema.properties[spec].properties[overrides].items.properties[clusterOverrides].items.properties[value].type:
      Required value: must not be empty for specified object fields, spec.versions[0].schema.openAPIV3Schema.type:
      Required value: must not be empty at the root]'
    reason: Violations
    status: "True"
    type: NonStructuralSchema
```