### PR TITLE
Fix unit test failing with Go1.14+

### DIFF
--- a/pkg/apis/core/v1beta1/validation/validation_test.go
+++ b/pkg/apis/core/v1beta1/validation/validation_test.go
@@ -446,11 +446,11 @@ func TestValidateAPIEndpoint(t *testing.T) {
 		},
 		{
 			"example.com:port80",
-			`apiEndpoint: Invalid value: "example.com:port80": parse https://example.com:port80: invalid port ":port80" after host`,
+			`invalid port`,
 		},
 		{
 			"example.com:-80",
-			`apiEndpoint: Invalid value: "example.com:-80": parse https://example.com:-80: invalid port ":-80" after host`,
+			`invalid port`,
 		},
 		{
 			"example.com:0",


### PR DESCRIPTION
**What this PR does / why we need it**:
The following tests will fail when run with Go 1.14+:
```
[root@ecs-d8b6 kubefed]# go test ./pkg/apis/core/v1beta1/validation/ -run=TestValidateAPIEndpoint -v
=== RUN   TestValidateAPIEndpoint
    TestValidateAPIEndpoint: validation_test.go:478: unexpected error: [apiEndpoint: Invalid value: "example.com:port80": parse "https://example.com:port80": invalid port ":port80" after host], expected: "apiEndpoint: Invalid value: \"exam"
    TestValidateAPIEndpoint: validation_test.go:478: unexpected error: [apiEndpoint: Invalid value: "example.com:-80": parse "https://example.com:-80": invalid port ":-80" after host], expected: "apiEndpoint: Invalid value: \"example.com:-"
--- FAIL: TestValidateAPIEndpoint (0.00s)
```
The difference is whether the string included by double quotation marks.
Got : `...parse "https://example.com:port80"...`
Expected: `...parse https://example.com:port80...`

The error msg printed by Go `net/url` package, but the formatting has been changed between Go1.13 and Go1.14.

Go 1.13.7
https://github.com/golang/go/blob/7d2473dc81c659fba3f3b83bc6e93ca5fe37a898/src/net/url/url.go#L29
```go
func (e *Error) Error() string { return e.Op + " " + e.URL + ": " + e.Err.Error() }
```

Go 1.14+
https://github.com/golang/go/blob/20a838ab94178c55bc4dc23ddc332fce8545a493/src/net/url/url.go#L29
```go
func (e *Error) Error() string { return fmt.Sprintf("%s %q: %s", e.Op, e.URL, e.Err) }
```

I think we shouldn't expect an individual message dump from the std package. 
So, this PR just change it to expect some key worlds.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
