### PR TITLE
chore: make cluster creation work with kind v0.7.0

### DIFF
--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -35,7 +35,7 @@ dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
 # kind
-kind_version="v0.4.0"
+kind_version="v0.7.0"
 kind_path="${dest_dir}/kind"
 kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64"
 curl -Lo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -150,8 +150,8 @@ run-unit-tests
 echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
-CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y OVERWRITE_KUBECONFIG=y \
-    KIND_TAG="v1.15.0" ./scripts/create-clusters.sh
+CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y \
+    KIND_TAG="v1.17.5" ./scripts/create-clusters.sh
 
 # Initialize list of clusters to join
 join-cluster-list > /dev/null


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The command 'kind get kubeconfig-path' has been deprecated in kind
v0.6.0 and removed in v0.7.0 so the cluster creation script doesn't
work with the latter version. To account for this fact and other
changes (such as kind now respecting `KUBECONFIG` and falling back to
the same defaults that `kubectl` uses), I reworked some parts of the
script.

pre-commit now uses the kind imave v1.17.5 for tests.

Note: This change makes the scripts fail to work with
      kind version < v0.7.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1220

**Special notes for your reviewer**:
