### PR TITLE
Revert "Fix event source namespace"

### DIFF
--- a/pkg/controller/sync/accessor.go
+++ b/pkg/controller/sync/accessor.go
@@ -180,8 +180,8 @@ func (a *resourceAccessor) HasSynced() bool {
 }
 
 func (a *resourceAccessor) FederatedResource(eventSource util.QualifiedName) (FederatedResource, bool, error) {
-	if a.targetIsNamespace && a.isSystemNamespace(eventSource.Namespace) {
-		klog.V(7).Infof("Ignoring system namespace %q", eventSource.Namespace)
+	if a.targetIsNamespace && a.isSystemNamespace(eventSource.Name) {
+		klog.V(7).Infof("Ignoring system namespace %q", eventSource.Name)
 		return nil, false, nil
 	}
 


### PR DESCRIPTION
Reverts kubernetes-sigs/kubefed#1225

As mentioned by @zhouya0, when eventSource comes from a namespace resource, it might be :

```
Name: "test-namesapce"
Namespace: ""
```

Or in the case of a federated type namespace:

```
Name: "test-namespace/test-namespace"
Namespace: "test-namespace"
```

The function `isSystemNamespace` handles both scenarios:

```
func (a *resourceAccessor) isSystemNamespace(namespace string) bool {
	// TODO(font): Need a configurable or discoverable list of namespaces
	// to not propagate beyond just the default system namespaces e.g.
	switch namespace {
	case "kube-system", "kube-public", "default", a.fedNamespace:
		return true
	default:
		return false
	}
}
```

therefore we need to revert this change.

