### PR TITLE
ingress-nginx master changed, so use nginx-0.32.0

### DIFF
--- a/docs/ingress-service-dns-with-coredns.md
+++ b/docs/ingress-service-dns-with-coredns.md
@@ -163,12 +163,10 @@ EOF
 ### Enable the ingress controller
 
 ```bash
-$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/mandatory.yaml
-$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/provider/baremetal/service-nodeport.yaml
+$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-0.32.0/deploy/static/provider/cloud/deploy.yaml
 $ kubectl --context cluster1 patch svc ingress-nginx -n ingress-nginx -p '{"spec": {"type": "LoadBalancer"}}'
 
-$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/mandatory.yaml
-$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/provider/baremetal/service-nodeport.yaml
+$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-0.32.0/deploy/static/provider/cloud/deploy.yaml
 $ kubectl --context cluster2 patch svc ingress-nginx -n ingress-nginx -p '{"spec": {"type": "LoadBalancer"}}'
 ```
 

--- a/docs/ingress-service-dns-with-coredns.md
+++ b/docs/ingress-service-dns-with-coredns.md
@@ -163,12 +163,12 @@ EOF
 ### Enable the ingress controller
 
 ```bash
-$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
-$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/baremetal/service-nodeport.yaml
+$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/mandatory.yaml
+$ kubectl --context cluster1 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/provider/baremetal/service-nodeport.yaml
 $ kubectl --context cluster1 patch svc ingress-nginx -n ingress-nginx -p '{"spec": {"type": "LoadBalancer"}}'
 
-$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
-$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/provider/baremetal/service-nodeport.yaml
+$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/mandatory.yaml
+$ kubectl --context cluster2 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/nginx-0.22.0/deploy/provider/baremetal/service-nodeport.yaml
 $ kubectl --context cluster2 patch svc ingress-nginx -n ingress-nginx -p '{"spec": {"type": "LoadBalancer"}}'
 ```
 


### PR DESCRIPTION
**What this PR does / why we need it**:

use old tag of ingress nginx repo
https://github.com/kubernetes/ingress-nginx/tree/nginx-0.22.0/deploy

master branch：
https://github.com/kubernetes/ingress-nginx/tree/master/deploy


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

> [root@xxx-10-6-177-41 ~]# kubectl --context paco308 apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml
> error: unable to read URL "https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/mandatory.yaml", server reported 404 Not Found, status code=404
> 

**Special notes for your reviewer**:

Or you will get 404 error like above

