### PR TITLE
cleanup legacy context after delete cluster

### DIFF
--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -33,6 +33,11 @@ function delete-clusters() {
   local num_clusters=${1}
 
   for i in $(seq ${num_clusters}); do
+    # The context name has been changed when creating clusters by 'create-cluster.sh'.
+    # This will result in the context can't be removed by kind when deleting a cluster.
+    # So, we need to change context name back and let kind take care about it.
+    kubectl config rename-context "cluster${i}" "kind-cluster${i}"
+
     kind delete cluster --name cluster${i}
   done
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Kube config context didn't be removed after delete clusters, that would block creating cluster next time as same context is already exist. You can reproduce it by following command.
```
# ./scripts/create-clusters.sh
# ./scripts/delete-clusters.sh
# kubectl config view
apiVersion: v1
clusters: null
contexts:
- context:
    cluster: kind-cluster1
    user: kind-cluster1
  name: cluster1
- context:
    cluster: kind-cluster2
    user: kind-cluster2
  name: cluster2
current-context: cluster1
kind: Config
preferences: {}
users: null
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
With this patch, we can get a clean config as follows:
```
# kubectl config view
apiVersion: v1
clusters: null
contexts: null
current-context: ""
kind: Config
preferences: {}
users: null
```