### PR TITLE
increase resource limits for kubefed controller

### DIFF
--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -13,8 +13,8 @@ controllermanager:
   imagePullPolicy: IfNotPresent
   resources:
     limits:
-      cpu: 100m
-      memory: 128Mi
+      cpu: 500m
+      memory: 512Mi
     requests:
       cpu: 100m
       memory: 64Mi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Default [resource limits](https://github.com/kubernetes-sigs/kubefed/blob/master/charts/kubefed/values.yaml#L15-L17) in the chart is too low now, it's easy to cause OOM issues, like #1235. Enlarge kubefed controller resource limits would cover more cases.
```yaml
  resources:
    limits:
      cpu: 100m
      memory: 128Mi
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1235 

**Special notes for your reviewer**:
