### PR TITLE
Correct docs for a Cluster Selector case

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -777,8 +777,6 @@ spec:
 
 ### `spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided but empty
 
-In this case, `spec.placement.clusters` will be ignored, since only
-`spec.placement.clusterSelector` is provided.
 
 ```yaml
 spec:

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -777,9 +777,8 @@ spec:
 
 ### `spec.placement.clusters` is not provided, `spec.placement.clusterSelector` is provided but empty
 
-In this case, `spec.placement.clusterSelector` will be ignored, since
-`spec.placement.clusters` is provided. This ensures that the results of runtime
-scheduling have priority over manual definition of a cluster selector.
+In this case, `spec.placement.clusters` will be ignored, since only
+`spec.placement.clusterSelector` is provided.
 
 ```yaml
 spec:


### PR DESCRIPTION
While browsing I found that an example in the **Cluster Selector** part of the _userguide_ has a volatile mistake.
