### PR TITLE
Set default log level for kubefed controller manager.

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -22,6 +22,7 @@ spec:
       containers:
       - command:
         - /hyperfed/controller-manager
+        - "--v={{ .Values.logLevel }}"
         image: "{{ .Values.repository }}/{{ .Values.image }}:{{ .Values.tag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
         name: controller-manager

--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -11,6 +11,7 @@ controllermanager:
   image: kubefed
   tag: canary
   imagePullPolicy: IfNotPresent
+  logLevel: 2
   resources:
     limits:
       cpu: 500m


### PR DESCRIPTION
**What this PR does / why we need it**:
Set default log level to `2` for the controller manager.
With this level, more useful logs would be printed and without much noise.

**Which issue(s) this PR fixes** :
Fixes #1246

**Special notes for your reviewer**:
