### PR TITLE
fix: pass correct values to Helm release in deploy script

### DIFF
--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -97,7 +97,7 @@ function helm-deploy-cmd {
   echo "helm install charts/kubefed --name ${name} --namespace ${ns} \
       --set controllermanager.controller.repository=${repo} \
       --set controllermanager.controller.image=${image} \
-      --set controllermanager.controller.tag=${tag}" \
+      --set controllermanager.controller.tag=${tag} \
       --set controllermanager.webhook.repository=${repo} \
       --set controllermanager.webhook.image=${image} \
       --set controllermanager.webhook.tag=${tag}"

--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -95,8 +95,12 @@ function helm-deploy-cmd {
   local tag="${5}"
 
   echo "helm install charts/kubefed --name ${name} --namespace ${ns} \
-      --set controllermanager.repository=${repo} --set controllermanager.image=${image} \
-      --set controllermanager.tag=${tag}"
+      --set controllermanager.controller.repository=${repo} \
+      --set controllermanager.controller.image=${image} \
+      --set controllermanager.controller.tag=${tag}" \
+      --set controllermanager.webhook.repository=${repo} \
+      --set controllermanager.webhook.image=${image} \
+      --set controllermanager.webhook.tag=${tag}"
 }
 
 function kubefed-admission-webhook-ready() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The structure has been changed in
12b16661959272f01f1ae7b700ba2acbda43722e but the deploy script has
not, which led to the e2e cluster always loading the default image
quay.io/kubernetes-multicluster/kubefed:canary.

This commit changes the deploy script accordingly so that it passes in
the correct values again.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
no issue

**Special notes for your reviewer**:
