### PR TITLE
Improvements to deploy-kubefed.sh script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ TEST = $(TEST_CMD) $(TEST_PKGS)
 DOCKER_BUILD ?= $(DOCKER) run -it --rm -v $(DIR):$(BUILDMNT) -w $(BUILDMNT) $(BUILD_IMAGE) /bin/sh -c
 
 # TODO (irfanurrehman): can add local compile, and auto-generate targets also if needed
-.PHONY: all container push clean hyperfed controller kubefedctl test local-test vet fmt build bindir generate webhook e2e
+.PHONY: all container push clean hyperfed controller kubefedctl test local-test vet fmt build bindir generate webhook e2e deploy.kind
 
 all: container hyperfed controller kubefedctl webhook e2e
 
@@ -164,3 +164,6 @@ clean:
 
 controller-gen:
 	command -v controller-gen &> /dev/null || (cd tools && go install sigs.k8s.io/controller-tools/cmd/controller-gen)
+
+deploy.kind:
+	DOCKER_PUSH= KIND_LOAD_IMAGE=y ./scripts/deploy-kubefed.sh $(IMAGE_NAME)

--- a/docs/development.md
+++ b/docs/development.md
@@ -247,6 +247,16 @@ the steps [documented
 above](#setup-clusters-and-deploy-the-kubefed-control-plane)
 to create your clusters.
 
+As a convenience, when deploying the kubefed control plane on a kind cluster
+without pushing the Docker images, you can also run:
+
+```bash
+make deploy.kind
+```
+
+This command can be run multiple times to redeploy kubefed when any code changes
+have been made.
+
 ## Test Latest Master Changes (`canary`)
 
 In order to test the latest master changes (tagged as `canary`) on your

--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -173,6 +173,13 @@ if [[ ! "${USE_LATEST}" ]]; then
   cd -
   ${DOCKER_PUSH_CMD}
 fi
+
+# Use KIND_LOAD_IMAGE=y DOCKER_PUSH= ./scripts/deploy-kubefed.sh <image> to load
+# the built docker image into kind before deploying.
+if [[ "${KIND_LOAD_IMAGE:-}" == "y" ]]; then
+    kind load docker-image ${IMAGE_NAME}
+fi
+
 cd "$(dirname "$0")/.."
 make kubefedctl
 cd -


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates `deploy-kubefed.sh` script so it has better support for deploying locally on kind and enabling running deploy script multiple times.

This PR also includes a new `Makefile` target, `deploy.kind`, to run `deploy-kubefed.sh` easily against local kind clusters without having to push to a Docker registry.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
