### PR TITLE
Helm chart tidy up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,4 +166,4 @@ controller-gen:
 	command -v controller-gen &> /dev/null || (cd tools && go install sigs.k8s.io/controller-tools/cmd/controller-gen)
 
 deploy.kind:
-	DOCKER_PUSH= KIND_LOAD_IMAGE=y ./scripts/deploy-kubefed.sh $(IMAGE_NAME)
+	DOCKER_PUSH=n KIND_LOAD_IMAGE=y FORCE_REDEPLOY=y ./scripts/deploy-kubefed.sh $(IMAGE_NAME)

--- a/charts/kubefed/Chart.yaml
+++ b/charts/kubefed/Chart.yaml
@@ -2,3 +2,8 @@ apiVersion: v2
 description: KubeFed helm chart
 name: kubefed
 version: 0.0.3
+dependencies:
+- name: controllermanager
+  version: 0.0.3
+  repository: "https://localhost/" # Required but unused.
+  condition: controllermanager.enabled

--- a/charts/kubefed/charts/controllermanager/templates/deployments.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/deployments.yaml
@@ -15,6 +15,10 @@ spec:
     metadata:
       labels:
         kubefed-control-plane: controller-manager
+      {{- if .Values.controller.forceRedeployment }}
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
     spec:
       securityContext:
         runAsUser: 1001
@@ -65,6 +69,10 @@ spec:
     metadata:
       labels:
         kubefed-admission-webhook: "true"
+      {{- if .Values.webhook.forceRedeployment }}
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
+      {{- end }}
     spec:
       securityContext:
         runAsUser: 1001

--- a/charts/kubefed/requirements.yaml
+++ b/charts/kubefed/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: controllermanager
-  version: 0.0.2
-  condition: controllermanager.enabled

--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -33,6 +33,7 @@ controllermanager:
     tag: canary
     imagePullPolicy: IfNotPresent
     logLevel: 2
+    forceRedeployment: false
     env: {}
     resources:
       limits:
@@ -47,6 +48,7 @@ controllermanager:
     tag: canary
     imagePullPolicy: IfNotPresent
     logLevel: 8
+    forceRedeployment: false
     env: {}
     resources:
       limits:

--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -68,18 +68,20 @@ function helm-deploy-cmd {
   local repo="${3}"
   local image="${4}"
   local tag="${5}"
-  local commonFlags="--namespace ${ns} \
-                     --set controllermanager.controller.repository=${repo} \
-                     --set controllermanager.controller.image=${image} \
-                     --set controllermanager.controller.tag=${tag} \
-                     --set controllermanager.webhook.repository=${repo} \
-                     --set controllermanager.webhook.image=${image} \
-                     --set controllermanager.webhook.tag=${tag}"
-  if [ -z "$(helm list ${name} --deployed -q)" ]; then
-    echo "helm install ${name} charts/kubefed ${commonFlags} --create-namespace"
-  else
-    echo "helm upgrade ${name} charts/kubefed --recreate-pods ${commonFlags}"
+  if [[ "${FORCE_REDEPLOY:-}" == "y" ]]; then
+    local force_redeploy_values="--set controllermanager.controller.forceRedeployment=true --set controllermanager.webhook.forceRedeployment=true"
   fi
+  echo "helm upgrade -i ${name} charts/kubefed \
+        --namespace ${ns} \
+        --set controllermanager.controller.repository=${repo} \
+        --set controllermanager.controller.image=${image} \
+        --set controllermanager.controller.tag=${tag} \
+        --set controllermanager.webhook.repository=${repo} \
+        --set controllermanager.webhook.image=${image} \
+        --set controllermanager.webhook.tag=${tag} \
+        ${force_redeploy_values:-} \
+        --create-namespace \
+        --wait"
 }
 
 function kubefed-admission-webhook-ready() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Tidies up some deployment things from the helm3 chart migration, namely:

- Moves dependencies into `Chart.yaml` as recommended by Helm 3 chart guide
- Adds `forceRedeployment` option to chart to work around removal of `--recreate-pods` flag in upcoming helm 3 versions
- Adds `--wait` for deployments to finish
- Minor tidy up in `deploy-kubefed.sh` script

FYI @eumel8 @alejandroEsc

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
