### PR TITLE
chore: webhook functions now return AdmissionResponse

### DIFF
--- a/pkg/controller/webhook/federatedtypeconfig/webhook.go
+++ b/pkg/controller/webhook/federatedtypeconfig/webhook.go
@@ -18,7 +18,11 @@ package federatedtypeconfig
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -38,29 +42,36 @@ type FederatedTypeConfigAdmissionHook struct{}
 var _ admission.Handler = &FederatedTypeConfigAdmissionHook{}
 
 func (a *FederatedTypeConfigAdmissionHook) Handle(ctx context.Context, admissionSpec admission.Request) admission.Response {
-	status := admission.Response{}
-
 	klog.V(4).Infof("Validating %q AdmissionRequest = %s", ResourceName, webhook.AdmissionRequestDebugString(admissionSpec))
 
 	// We want to let through:
 	// - Requests that are not for create, update
 	// - Requests for things that are not FederatedTypeConfigs
-	if webhook.Allowed(admissionSpec, resourcePluralName, &status) {
-		return status
+	if webhook.Allowed(admissionSpec, resourcePluralName) {
+		return admission.Response{
+			AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				Allowed: true,
+			},
+		}
 	}
 
 	admittingObject := &v1beta1.FederatedTypeConfig{}
-	err := webhook.Unmarshal(&admissionSpec.Object, admittingObject, &status)
-	if err != nil {
-		return status
+	if err := json.Unmarshal(admissionSpec.Object.Raw, admittingObject); err != nil {
+		return admission.Response{
+			AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+					Message: err.Error(),
+				},
+			},
+		}
 	}
 
 	klog.V(4).Infof("Validating %q = %+v", ResourceName, *admittingObject)
 
 	isStatusSubResource := len(admissionSpec.SubResource) != 0
-	webhook.Validate(&status, func() field.ErrorList {
+	return webhook.Validate(func() field.ErrorList {
 		return validation.ValidateFederatedTypeConfig(admittingObject, isStatusSubResource)
 	})
-
-	return status
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Having these functions modify the AdmissionResponse passed in as
parameter makes it hard to reason about the code.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1267 

**Special notes for your reviewer**:
