### PR TITLE
chore: use cert-mananager.io/v1 group/version

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -15,7 +15,7 @@ metadata:
 {{- end }}
   annotations:
   {{- if .Values.certManager.enabled }}
-    {{ .Values.certManager.apiGroup }}/inject-ca-from: {{ printf "%s/%s%s" .Release.Namespace .Release.Name "-root-certificate" | quote }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s%s" .Release.Namespace .Release.Name "-root-certificate" | quote }}
   {{- end }}
 webhooks:
 - name: federatedtypeconfigs.core.kubefed.io
@@ -152,7 +152,7 @@ stringData:
   tls.key: {{ $cert.Key | quote }}
 {{- else }}
 ---
-apiVersion: {{ .Values.certManager.apiGroup }}/{{ .Values.certManager.apiVersion }}
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Release.Name }}-ca-issuer
@@ -160,7 +160,7 @@ spec:
   selfSigned: {}
 ---
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: {{ .Values.certManager.apiGroup }}/{{ .Values.certManager.apiVersion }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Release.Name}}-root-certificate
@@ -173,7 +173,7 @@ spec:
   isCA: true
 ---
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: {{ .Values.certManager.apiGroup }}/{{ .Values.certManager.apiVersion }}
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Release.Name }}-issuer
@@ -182,7 +182,7 @@ spec:
     secretName: {{ .Release.Name}}-root-ca
 ---
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: {{ .Values.certManager.apiGroup }}/{{ .Values.certManager.apiVersion }}
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ .Release.Name }}-certificate

--- a/charts/kubefed/values.yaml
+++ b/charts/kubefed/values.yaml
@@ -62,9 +62,6 @@ controllermanager:
 
   certManager:
     enabled: false
-    apiGroup: certmanager.k8s.io
-    apiVersion: v1alpha1
-
 
 ## Configuration global values for all charts
 ##


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Changes cert-manager resources to those whose group/version are "cert-manager.io/v1"

This was tested on a kind cluster with the latest version of cert-manager. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
