### PR TITLE
chore: remove deprecated chart from repo

### DIFF
--- a/charts/index.yaml
+++ b/charts/index.yaml
@@ -1,30 +1,5 @@
 apiVersion: v1
 entries:
-  federation-v2:
-  - apiVersion: v1
-    created: "2019-05-06T15:30:47.795749649-07:00"
-    description: Kubernetes Federation V2 helm chart
-    digest: 9b248eed6f021951653ee98cb255d2d3564748ac04c2484c941f619c39c5dd79
-    name: federation-v2
-    urls:
-    - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.10/federation-v2-0.0.10.tgz
-    version: 0.0.10
-  - apiVersion: v1
-    created: "2019-04-29T22:11:58.917695043-07:00"
-    description: Kubernetes Federation V2 helm chart
-    digest: b0dc5f35ef7b5fcc8604881d97a033af2cbdb5ea221b4702ca098bc4ef1c7dc5
-    name: federation-v2
-    urls:
-    - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.9/federation-v2-0.0.9.tgz
-    version: 0.0.9
-  - apiVersion: v1
-    created: "2019-04-10T22:19:18.130342567-07:00"
-    description: Kubernetes Federation V2 helm chart
-    digest: 99e3236f43ac81dbdf04e9ad47914e5782dbb6a97a5bb2bf9d2d6ec3d73d9afc
-    name: federation-v2
-    urls:
-    - https://github.com/kubernetes-sigs/federation-v2/releases/download/v0.0.8/federation-v2-0.0.8.tgz
-    version: 0.0.8
   kubefed:
   - apiVersion: v2
     created: "2020-08-17T17:14:21.241083506+01:00"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Removing the old federation-v2 from the Helm repo as this chart just leads to confusion on user's side and it's deprecated,
anyway.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
no issue

**Special notes for your reviewer**:
