### PR TITLE
fix: prefer core resources when enabling a type

### DIFF
--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -128,6 +128,12 @@ The `<target kubernetes API type>` can be any of the following
 
 for the intended target API type.
 
+**NOTE:** To specifically target a type of a certain API group, you can append the group's name as in `deployment.apps`.
+For core Kubernetes types such as `Pod` or `Service` this is not possible because they have no specific API group assigned
+to them. Therefore, core types always take precendence over other types of the same name from another API group. Please
+see the [Enabling an API type with a non-default API group](#enabling-an-api-type-with-a-non-default-api-group) section
+for more information on the impact of possible naming conflicts.
+
 The `kubefedctl` command will create
  - a CRD for the federated type named `Federated<Kind>`
  - a `FederatedTypeConfig` in the KubeFed system namespace with the group-qualified plural name of the target type.

--- a/pkg/kubefedctl/enable/util.go
+++ b/pkg/kubefedctl/enable/util.go
@@ -106,6 +106,13 @@ func LookupAPIResource(config *rest.Config, key, targetVersion string) (*metav1.
 					targetResource = resource.DeepCopy()
 					targetResource.Group = group
 					targetResource.Version = gv.Version
+					// a resource from the 'core' group matches the 'key', so we prefer
+					// that one over any other because otherwise there would be no way
+					// for the user to signify that he wants to enable federation of
+					// a specific core group resource.
+					if targetResource.Group == "" {
+						return targetResource, nil
+					}
 				}
 				matchedResources = append(matchedResources, groupQualifiedName(resource.Name, gv.Group))
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When a resource type such as `pods` is `services` is passed to
`kubefedctl enable` and there's a match for this name in the `core`
group as well as another group, there was no way to tell `kubefedctl`
that the `core` resource should be enabled.

Now, whenever an API resource from the `core` group matches the
desired type to be enabled, this resource type is preferred.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1078 

**Special notes for your reviewer**:
Here's the steps to test this:

-  `kind create cluster`
- `kubectl apply --filename https://github.com/knative/serving/releases/download/v0.18.0/serving-crds.yaml`
- `make kubefedctl`
- `./bin/kubefedctl enable services --kubefed-namespace="default" -o yaml`

Before this change:
```
$ ./bin/kubefedctl enable services --kubefed-namespace="default" -o yaml
F1012 22:22:47.217201   66506 enable.go:111] Error: Multiple resources are matched by "services": services, services.serving.knative.dev. A group-qualified plural name must be provided.
```

With this change:
```
$ ./bin/kubefedctl enable services --kubefed-namespace="default" -o yaml
---
apiVersion: core.kubefed.io/v1beta1
kind: FederatedTypeConfig
[...]
```