### PR TITLE
chore: Use Kubernetes v1.19.1 and kind v0.9.0 for testing

### DIFF
--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -35,7 +35,7 @@ dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
 # kind
-kind_version="v0.7.0"
+kind_version="v0.9.0"
 kind_path="${dest_dir}/kind"
 kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64"
 curl -Lo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -149,7 +149,7 @@ echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
 CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y \
-    KIND_TAG="v1.18.4" ./scripts/create-clusters.sh
+    KIND_TAG="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600" ./scripts/create-clusters.sh
 
 # Initialize list of clusters to join
 join-cluster-list > /dev/null


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades to use Kind v0.9.0 and Kubernetes v1.19.1. This is to unblock #1301 as a separate PR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I haven't tested this on a Mac so help there would be appreciated. @makkes I see you've previously touched these files and I'm pretty sure you're a Mac user - would you be able to help our here? This can be tested with

```shell
$ DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh`
```

and cleaned up with

```shell
DELETE_INSECURE_REGISTRY=y ./scripts/delete-clusters.sh
```