### PR TITLE
chore: Remove need for insecure registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,4 +166,4 @@ controller-gen:
 	command -v controller-gen &> /dev/null || (cd tools && go install sigs.k8s.io/controller-tools/cmd/controller-gen)
 
 deploy.kind:
-	DOCKER_PUSH=n KIND_LOAD_IMAGE=y FORCE_REDEPLOY=y ./scripts/deploy-kubefed.sh $(IMAGE_NAME)
+	KIND_LOAD_IMAGE=y FORCE_REDEPLOY=y ./scripts/deploy-kubefed.sh $(IMAGE_NAME)

--- a/docs/environments/kind.md
+++ b/docs/environments/kind.md
@@ -5,12 +5,7 @@
 - [`kind` - `k`ubernetes `in` `d`ocker](#kind---kubernetes-in-docker)
   - [Download and Install kind](#download-and-install-kind)
   - [Create Clusters](#create-clusters)
-    - [Create Insecure Container Registry](#create-insecure-container-registry)
-    - [Configure Insecure Container Registry](#configure-insecure-container-registry)
-    - [Run Script](#run-script)
   - [Delete Clusters](#delete-clusters)
-    - [Delete Insecure Container Registry](#delete-insecure-container-registry)
-    - [Run Script](#run-script-1)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -35,69 +30,6 @@ will be installed. Your `GOBIN` directory should be at `$(go env GOPATH)/bin`:
 
 You can proceed to create clusters once you have `kind` available in your path.
 
-### Create Insecure Container Registry
-
-Please answer the following question to determine if you need to set up an
-insecure container registry on your host:
-
-1. Are you planning on creating container images locally without pushing to a
-   public container registry such as `quay.io`. For example, you can build your
-   own custom image e.g. `172.17.0.1:5000/<imagename>:<tag>`, as part of your
-   development workflow and push to this container registry . See the
-   [development guide](/docs/development.md#test-your-changes) for more
-   examples.
-
-If you answered yes, then you will need to create an insecure container
-registry. Creating a container registry is necessary if you want your kind
-clusters to pull images that you built locally on your host without pushing
-them to a public container registry. See the [docker
-docs](https://docs.docker.com/registry) for more details.
-
-In order to create an insecure container registry, you can pass the
-`CREATE_INSECURE_REGISTRY` flag to `create-clusters.sh` as follows:
-
-```bash
-CREATE_INSECURE_REGISTRY=y ./scripts/create-clusters.sh
-```
-
-### Configure Insecure Container Registry
-
-Please answer the following questions to determine if you need to configure an
-insecure container registry on your host:
-
-1. Is this the first time you're running the `create-clusters.sh` script?
-2. Does your docker daemon need to be configured for an insecure container
-   registry?
-
-If you answered yes to both of these questions, then you will need to configure
-the docker daemon on your host for an insecure container registry. The reason
-for an insecure registry is to simplify the container registry setup by not
-enabling TLS. **This only needs to be done once for a particular host**.
-See the [docker docs](https://docs.docker.com/registry) for more details.
-
-In order to configure an insecure container registry, you can pass the
-`CONFIGURE_INSECURE_REGISTRY_HOST` flag to `create-clusters.sh` as shown below. The
-default container registry host is `172.17.0.1:5000` and needs to match
-the IP address of the default docker bridge on your host, typically
-`172.17.0.1`. If you would like to change this then set the
-`CONTAINER_REGISTRY_HOST="<host>:<port>"` flag.
-
-```bash
-CONFIGURE_INSECURE_REGISTRY_HOST=y ./scripts/create-clusters.sh
-```
-
-This will automatically create the necessary dockerd daemon config and reload
-the docker daemon for you. Keep in mind that it will **not** do this for you
-if a config already exists, or your docker daemon is already configured with an
-`--insecure-registry` command line option.
-
-If you would like to manually make the changes to your docker daemon instead,
-add `172.17.0.1:5000` as an insecure registry host and reload or restart your
-docker daemon. See the [docker
-docs](https://docs.docker.com/registry/insecure/) for more details.
-
-### Run Script
-
 Run the following command to create `2` `kind` clusters:
 
 ```bash
@@ -112,17 +44,6 @@ NUM_CLUSTERS=<num> ./scripts/create-clusters.sh
 ```
 
 ## Delete Clusters
-
-### Delete Insecure Container Registry
-
-Specify the `DELETE_INSECURE_REGISTRY` flag if you set up an insecure container
-registry and would like to have it deleted.
-
-```bash
-DELETE_INSECURE_REGISTRY=y ./scripts/delete-clusters.sh
-```
-
-### Run Script
 
 Run the following command to delete `2` `kind` clusters:
 

--- a/scripts/delete-clusters.sh
+++ b/scripts/delete-clusters.sh
@@ -21,33 +21,22 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DELETE_INSECURE_REGISTRY="${DELETE_INSECURE_REGISTRY:-}"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
-
-function delete-insecure-registry() {
-  docker kill registry &> /dev/null || return 0
-  docker rm registry &> /dev/null || true
-}
 
 function delete-clusters() {
   local num_clusters=${1}
 
-  for i in $(seq ${num_clusters}); do
+  for i in $(seq "${num_clusters}"); do
     # The context name has been changed when creating clusters by 'create-cluster.sh'.
     # This will result in the context can't be removed by kind when deleting a cluster.
     # So, we need to change context name back and let kind take care about it.
     kubectl config rename-context "cluster${i}" "kind-cluster${i}"
 
-    kind delete cluster --name cluster${i}
+    kind delete cluster --name "cluster${i}"
   done
 }
 
-if [[ "${DELETE_INSECURE_REGISTRY}" ]]; then
-  echo "Deleting container registry on host"
-  delete-insecure-registry
-fi
-
 echo "Deleting ${NUM_CLUSTERS} clusters"
-delete-clusters ${NUM_CLUSTERS}
+delete-clusters "${NUM_CLUSTERS}"
 
 echo "Complete"

--- a/scripts/download-e2e-binaries.sh
+++ b/scripts/download-e2e-binaries.sh
@@ -35,10 +35,11 @@ dest_dir="${root_dir}/bin"
 mkdir -p "${dest_dir}"
 
 # kind
+platform="$(uname -s|tr A-Z a-z)"
 kind_version="v0.9.0"
 kind_path="${dest_dir}/kind"
-kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-linux-amd64"
-curl -Lo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"
+kind_url="https://github.com/kubernetes-sigs/kind/releases/download/${kind_version}/kind-${platform}-amd64"
+curl -fLo "${kind_path}" "${kind_url}" && chmod +x "${kind_path}"
 
 # Pull the busybox image (used in tests of workload types)
 docker pull busybox

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -20,8 +20,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-source "$(dirname "${BASH_SOURCE}")/util.sh"
-ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
+# shellcheck source=util.sh
+source "${BASH_SOURCE%/*}/util.sh"
+ROOT_DIR="$(cd "${BASH_SOURCE%/*}/.." ; pwd)"
 TEMP_DIR="$(mktemp -d)"
 MAKE_CMD="make -C ${ROOT_DIR}"
 OS="$(go env GOOS)"
@@ -30,7 +31,6 @@ PLATFORM="${OS}-${ARCH}"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 JOIN_CLUSTERS="${JOIN_CLUSTERS:-}"
 DOWNLOAD_BINARIES="${DOWNLOAD_BINARIES:-}"
-CONTAINER_REGISTRY_HOST="${CONTAINER_REGISTRY_HOST:-172.17.0.1:5000}"
 COMMON_TEST_ARGS="-kubeconfig=${HOME}/.kube/config -ginkgo.v -single-call-timeout=1m -ginkgo.trace -ginkgo.randomizeAllSpecs"
 E2E_TEST_CMD="${TEMP_DIR}/e2e-${PLATFORM} ${COMMON_TEST_ARGS}"
 # Disable limited scope in-memory controllers to ensure the controllers in the
@@ -45,29 +45,17 @@ function build-binaries() {
   ${MAKE_CMD} e2e
   # Copying the test binary to ${TEMP_DIR} to ensure
   # there's no dependency on the static files in the path
-  cp ${ROOT_DIR}/bin/e2e-${PLATFORM} ${TEMP_DIR}
+  cp "${ROOT_DIR}/bin/e2e-${PLATFORM}" "${TEMP_DIR}"
 }
 
 function download-dependencies() {
-  if [[ -z "${DOWNLOAD_BINARIES}" ]]; then
-    return
+  if [[ "${DOWNLOAD_BINARIES:-}" == "y"  ]]; then
+    ./scripts/download-binaries.sh
   fi
-
-  ./scripts/download-binaries.sh
 }
 
 function run-unit-tests() {
   KUBEBUILDER_ASSETS=${ROOT_DIR}/bin ${MAKE_CMD} test
-}
-
-function join-cluster-list() {
-  if [[ -z "${JOIN_CLUSTERS}" ]]; then
-    for i in $(seq 2 ${NUM_CLUSTERS}); do
-      JOIN_CLUSTERS+="cluster${i} "
-    done
-    export JOIN_CLUSTERS=$(echo ${JOIN_CLUSTERS} | sed 's/ $//')
-  fi
-  echo "${JOIN_CLUSTERS}"
 }
 
 function run-e2e-tests() {
@@ -98,7 +86,7 @@ function check-git-state() {
     return
   fi
   echo "ERROR: the working tree is dirty:"
-  for line in "${output}"; do
+  for line in ${output}; do
     echo "${line}"
   done
   git diff
@@ -148,14 +136,17 @@ run-unit-tests
 echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
-CREATE_INSECURE_REGISTRY=y CONFIGURE_INSECURE_REGISTRY_HOST=y \
-    KIND_TAG="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600" ./scripts/create-clusters.sh
+KIND_TAG="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600" ./scripts/create-clusters.sh
 
-# Initialize list of clusters to join
-join-cluster-list > /dev/null
+declare -a join_cluster_list=() 
+if [[ -z "${JOIN_CLUSTERS}" ]]; then
+  for i in $(seq 2 "${NUM_CLUSTERS}"); do
+    join_cluster_list+=("cluster${i}")
+  done
+fi
 
 echo "Deploying cluster-scoped kubefed"
-./scripts/deploy-kubefed.sh ${CONTAINER_REGISTRY_HOST}/kubefed:e2e $(join-cluster-list)
+KIND_CLUSTER_NAME=cluster1 KIND_LOAD_IMAGE=y ./scripts/deploy-kubefed.sh local/kubefed:e2e "${join_cluster_list[@]-}"
 
 echo "Running e2e tests against cluster-scoped kubefed"
 run-e2e-tests
@@ -180,7 +171,7 @@ echo "Deleting cluster-scoped kubefed"
 ./scripts/delete-kubefed.sh
 
 echo "Deploying namespace-scoped kubefed"
-KUBEFED_NAMESPACE=foo NAMESPACED=y ./scripts/deploy-kubefed.sh ${CONTAINER_REGISTRY_HOST}/kubefed:e2e $(join-cluster-list)
+KUBEFED_NAMESPACE=foo NAMESPACED=y ./scripts/deploy-kubefed.sh local/kubefed:e2e "${join_cluster_list[@]}"
 
 echo "Running go e2e tests with namespace-scoped kubefed"
 run-namespaced-e2e-tests


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the need for the insecure registry deployment and configuration from running e2e tests locally with kind.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #496.

**Special notes for your reviewer**:
