### PR TITLE
fix: `make deploy.kind` didn't work, anymore.

### DIFF
--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -162,7 +162,7 @@ fi
 # Use KIND_LOAD_IMAGE=y ./scripts/deploy-kubefed.sh <image> to load
 # the built docker image into kind before deploying.
 if [[ "${KIND_LOAD_IMAGE:-}" == "y" ]]; then
-    kind load docker-image "${IMAGE_NAME}" --name="${KIND_CLUSTER_NAME:-}"
+    kind load docker-image "${IMAGE_NAME}" --name="${KIND_CLUSTER_NAME:-kind}"
 fi
 
 cd "$(dirname "$0")/.."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
After #1306 has been merged, `make deploy.kind` broke because it doesn't provide the`KIND_CLUSTER_NAME` variable. An empty default provided to `kind`'s `--name` parameter doesn't make much sense because `kind` will simply error out in that case so using a default of `kind` for the name is the solution that should work most of the time, especially when following the quick start guide in the README.md.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
