### PR TITLE
fix: klog verbosity detection

### DIFF
--- a/cmd/controller-manager/app/controller-manager.go
+++ b/cmd/controller-manager/app/controller-manager.go
@@ -93,16 +93,18 @@ member clusters and do the necessary reconciliation`,
 		},
 	}
 
-	// Add the command line flags from other dependencies(klog, kubebuilder, etc.)
-	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	flags := cmd.Flags()
+	opts.AddFlags(flags)
+	flags.StringVar(&healthzAddr, "healthz-addr", healthzDefaultBindAddress, "The address the healthz endpoint binds to.")
+	flags.StringVar(&metricsAddr, "metrics-addr", metricsDefaultBindAddress, "The address the metric endpoint binds to.")
+	flags.BoolVar(&verFlag, "version", false, "Prints the Version info of controller-manager.")
+	flags.StringVar(&kubeFedConfig, "kubefed-config", "", "Path to a KubeFedConfig yaml file. Test only.")
+	flags.StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
+	flags.StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 
-	opts.AddFlags(cmd.Flags())
-	cmd.Flags().StringVar(&healthzAddr, "healthz-addr", healthzDefaultBindAddress, "The address the healthz endpoint binds to.")
-	cmd.Flags().StringVar(&metricsAddr, "metrics-addr", metricsDefaultBindAddress, "The address the metric endpoint binds to.")
-	cmd.Flags().BoolVar(&verFlag, "version", false, "Prints the Version info of controller-manager.")
-	cmd.Flags().StringVar(&kubeFedConfig, "kubefed-config", "", "Path to a KubeFedConfig yaml file. Test only.")
-	cmd.Flags().StringVar(&kubeconfig, "kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
-	cmd.Flags().StringVar(&masterURL, "master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
+	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(local)
+	flags.AddGoFlagSet(local)
 
 	return cmd
 }

--- a/cmd/hyperfed/main.go
+++ b/cmd/hyperfed/main.go
@@ -30,12 +30,12 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, Openstack, etc
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 
 	ctrlapp "sigs.k8s.io/kubefed/cmd/controller-manager/app"
 	webhookapp "sigs.k8s.io/kubefed/cmd/webhook/app"
@@ -47,8 +47,11 @@ func main() {
 
 	hyperfedCommand, allCommandFns := NewHyperFedCommand()
 
-	pflag.CommandLine.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	flags := hyperfedCommand.Flags()
+	local := goflag.NewFlagSet(os.Args[0], goflag.ExitOnError)
+	klog.InitFlags(local)
+	flags.SetNormalizeFunc(utilflag.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(local)
 
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/pkg/kubefedctl/kubefedctl.go
+++ b/pkg/kubefedctl/kubefedctl.go
@@ -19,12 +19,13 @@ package kubefedctl
 import (
 	"flag"
 	"io"
+	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"k8s.io/client-go/tools/clientcmd"
 	apiserverflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog"
 
 	"sigs.k8s.io/kubefed/pkg/kubefedctl/enable"
 	"sigs.k8s.io/kubefed/pkg/kubefedctl/federate"
@@ -45,9 +46,12 @@ func NewKubeFedCtlCommand(out io.Writer) *cobra.Command {
 
 	// Add the command line flags from other dependencies (e.g., klog), but do not
 	// warn if they contain underscores.
-	pflag.CommandLine.SetNormalizeFunc(apiserverflag.WordSepNormalizeFunc)
-	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	rootCmd.PersistentFlags().AddFlagSet(pflag.CommandLine)
+	flags := rootCmd.Flags()
+	local := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	klog.InitFlags(local)
+	flags.SetNormalizeFunc(apiserverflag.WordSepNormalizeFunc)
+	flags.AddGoFlagSet(local)
+	rootCmd.PersistentFlags().AddFlagSet(flags)
 
 	// From this point and forward we get warnings on flags that contain "_" separators
 	rootCmd.SetGlobalNormalizationFunc(apiserverflag.WarnWordSepNormalizeFunc)


### PR DESCRIPTION
Signed-off-by: Hector Fernandez <hfernandez@mesosphere.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The verbosity level was not initialized to klog anymore, so the level of verbosity was the default one instead of the specified in the flags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1314 

**Special notes for your reviewer**:
