### PR TITLE
make create-clusters.sh work based on kind document

### DIFF
--- a/docs/environments/kind.md
+++ b/docs/environments/kind.md
@@ -43,6 +43,19 @@ script if you'd like to change the default:
 NUM_CLUSTERS=<num> ./scripts/create-clusters.sh
 ```
 
+The `KIND_TAG` is `v1.19.4@sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b` by default.
+Image `kindest/node:v1.19.4@sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b` is used as
+node docker image for booting the cluster.
+
+You can use `KIND_IMAGE` or `KIND_TAG` to specify the image as you want.
+```bash
+KIND_TAG=v1.18.8 ./scripts/create-clusters.sh
+```
+
+```bash
+KIND_IMAGE=kindest/node:v1.18.8 ./scripts/create-clusters.sh
+```
+
 ## Delete Clusters
 
 Run the following command to delete `2` `kind` clusters:

--- a/scripts/create-clusters.sh
+++ b/scripts/create-clusters.sh
@@ -25,7 +25,7 @@ set -o pipefail
 source "${BASH_SOURCE%/*}/util.sh"
 NUM_CLUSTERS="${NUM_CLUSTERS:-2}"
 KIND_IMAGE="${KIND_IMAGE:-}"
-KIND_TAG="${KIND_TAG:-}"
+KIND_TAG="${KIND_TAG:-v1.19.4@sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b}"
 OS="$(uname)"
 
 function create-clusters() {

--- a/scripts/pre-commit.sh
+++ b/scripts/pre-commit.sh
@@ -136,7 +136,7 @@ run-unit-tests
 echo "Downloading e2e test dependencies"
 ./scripts/download-e2e-binaries.sh
 
-KIND_TAG="v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600" ./scripts/create-clusters.sh
+KIND_TAG="v1.19.4@sha256:796d09e217d93bed01ecf8502633e48fd806fe42f9d02fdd468b81cd4e3bd40b" ./scripts/create-clusters.sh
 
 declare -a join_cluster_list=() 
 if [[ -z "${JOIN_CLUSTERS}" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The script should work based on documents.
1. I add default TAG for the node image to make it work by default.
2. I add 2 environment variables documented in kind doc

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1322

**Special notes for your reviewer**:
