### PR TITLE
chore: improve some of the deployment and build scripts

### DIFF
--- a/scripts/deploy-kubefed.sh
+++ b/scripts/deploy-kubefed.sh
@@ -173,8 +173,10 @@ cd -
 deploy-with-helm
 
 # Join the host cluster
-CONTEXT="$(kubectl config current-context)"
-./bin/kubefedctl join "${CONTEXT}" --host-cluster-context "${CONTEXT}" --v=2 "${KF_NS_ARGS}" --error-on-existing=false
+if [ -z "${NO_JOIN_HOST_CLUSTER:-}" ] ; then
+    CONTEXT="$(kubectl config current-context)"
+    ./bin/kubefedctl join "${CONTEXT}" --host-cluster-context "${CONTEXT}" --v=2 "${KF_NS_ARGS}" --error-on-existing=false
+fi
 
 for c in ${JOIN_CLUSTERS}; do
   ./bin/kubefedctl join "${c}" --host-cluster-context "${CONTEXT}" --v=2 "${KF_NS_ARGS}" --error-on-existing=false

--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -78,11 +78,11 @@ users: []
 EOF
 
 # Start kube-apiserver to generate CRDs
-${ROOT_DIR}/bin/etcd --data-dir ${WORKDIR} &
-util::wait-for-condition 'ok' "curl http://127.0.0.1:2379/version &> /dev/null" 30
+${ROOT_DIR}/bin/etcd --data-dir ${WORKDIR} --log-output stdout > ${WORKDIR}/etcd.log 2>&1 &
+util::wait-for-condition 'etcd' "curl http://127.0.0.1:2379/version &> /dev/null" 30
 
-${ROOT_DIR}/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir ${WORKDIR} &
-util::wait-for-condition 'ok' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context kubefed get --raw=/healthz &> /dev/null" 60
+${ROOT_DIR}/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir=${WORKDIR} --log-file=${WORKDIR}/kube-apiserver.log --logtostderr=false 2> /dev/null &
+util::wait-for-condition 'kube-apiserver' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context kubefed get --raw=/healthz &> /dev/null" 60
 
 # Generate YAML templates to enable resource propagation for helm chart.
 echo -n > ${CHART_FEDERATED_PROPAGATION_DIR}/templates/federatedtypeconfig.yaml
@@ -104,3 +104,4 @@ done
 kill %1 # etcd
 kill %2 # kube-apiserver
 rm -fr ${WORKDIR}
+echo "Helm chart synced successfully"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* deploy-kubefed.sh: new envvar `NO_JOIN_HOST_CLUSTER`. When set to a
  non-empty value prevents the script from joining the host cluster to
  itself. Default behaviour doesn't change.
* sync-up-helm-charts.sh: reduced verbosity of the script by letting
  etcd and kube-apiserver log into files instead of stdout/stderr.
  This should make it much easier to follow the steps the scripts is
  exercising. Also improved the two messages printed when waiting for
  etcd and kube-apiserver to get ready.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
n/a

**Special notes for your reviewer**:

No behaviour has been changed with respect to what the scripts do but only to how much information they log to stdout.