### PR TITLE
fix: value of retainReplicas isn't always respected

### DIFF
--- a/pkg/controller/util/propagatedversion.go
+++ b/pkg/controller/util/propagatedversion.go
@@ -55,7 +55,7 @@ func ObjectNeedsUpdate(desiredObj, clusterObj *unstructured.Unstructured, record
 	// If versions match and the version is sourced from the
 	// generation field, a further check of metadata equivalency is
 	// required.
-	return strings.HasPrefix(targetVersion, generationPrefix) && !ObjectMetaObjEquivalent(desiredObj, clusterObj)
+	return strings.HasPrefix(targetVersion, generationPrefix) && !ObjectMetaAndSpecUnstructuredEquivalent(desiredObj, clusterObj)
 }
 
 // SortClusterVersions ASCII sorts the given cluster versions slice


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When creating a `FederatedDeployment` with `retainReplicas` set to
`true`, the `spec.replicas` value of the target Deployment isn't
touched by kubefed. However, when changing that value on the
`FederatedDeployment` back to `false`, the
`spec.template.spec.replicas` value isn't propagated to the target
resource.

Therefore, the `util.ObjectNeedsUpdate` func now compares the `spec`
field of federated resources so that any changes in it are actually
taken into account when deciding whether to update the target resource
or not.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Refs #1278

**Special notes for your reviewer**:

I must admit I'm not sure whether this is the best way to solve the problem as it might impact performance given kubefed now compares the complete `spec` field.