### PR TITLE
Fix error on exiting

### DIFF
--- a/pkg/controller/util/cluster_util.go
+++ b/pkg/controller/util/cluster_util.go
@@ -41,10 +41,10 @@ import (
 const (
 	DefaultKubeFedSystemNamespace = "kube-federation-system"
 
-	KubeAPIQPS   = 20.0
-	KubeAPIBurst = 30
-	TokenKey     = "token"
-
+	KubeAPIQPS        = 20.0
+	KubeAPIBurst      = 30
+	TokenKey          = "token"
+	CaCrtKey          = "ca.crt"
 	KubeFedConfigName = "kubefed"
 )
 

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -899,7 +899,7 @@ func populateSecretInHostCluster(clusterClientset, hostClientset kubeclient.Inte
 					klog.ErrorS(err, "Could not update secret in host cluster", "secretName", secretName)
 					return nil, nil, err
 				}
-				klog.V(2).InfoS("Updated secret in host cluster", "secretName", secretName)
+				klog.InfoS("Updated secret in host cluster as member cluster's token changed", "secretName", secretName)
 				return secretUpdateResult, caBundle, nil
 			}
 		case err != nil && !apierrors.IsNotFound(err):

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -20,6 +20,12 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/klog/v2"
 
@@ -33,6 +39,7 @@ import (
 	"sigs.k8s.io/kubefed/pkg/controller/util"
 	"sigs.k8s.io/kubefed/pkg/kubefedctl"
 	kfenable "sigs.k8s.io/kubefed/pkg/kubefedctl/enable"
+	kfutil "sigs.k8s.io/kubefed/pkg/kubefedctl/util"
 	"sigs.k8s.io/kubefed/test/common"
 	"sigs.k8s.io/kubefed/test/e2e/framework"
 
@@ -120,12 +127,63 @@ var _ = Describe("Simulated Scale", func() {
 			joiningNamespace := memberCluster
 			secretName := memberCluster
 
-			_, err := kubefedctl.TestOnlyJoinClusterForNamespace(
+			_, errJoin := kubefedctl.TestOnlyJoinClusterForNamespace(
 				hostConfig, hostConfig, hostNamespace,
 				joiningNamespace, hostCluster, memberCluster,
 				secretName, apiextv1.NamespaceScoped, false, false)
 
+			// rejoin cluster, and secret not change
 			_, errReJoin := kubefedctl.TestOnlyJoinClusterForNamespace(
+				hostConfig, hostConfig, hostNamespace,
+				joiningNamespace, hostCluster, memberCluster,
+				secretName, apiextv1.NamespaceScoped, false, false)
+
+			// serviceaccount token recreate
+			saName := kfutil.ClusterServiceAccountName(memberCluster, hostCluster)
+			var deleteSecret sync.Once
+			err = wait.PollImmediate(1*time.Second, 10*time.Second, func() (bool, error) {
+				sa, err := client.CoreV1().ServiceAccounts(joiningNamespace).Get(
+					context.Background(), saName, metav1.GetOptions{},
+				)
+				if err != nil {
+					return false, nil
+				}
+
+				// delete secret, make token regenerate
+				deleteSecret.Do(func() {
+					for _, objReference := range sa.Secrets {
+						saSecretName := objReference.Name
+						secret, err := client.CoreV1().Secrets(joiningNamespace).Get(
+							context.Background(), saSecretName, metav1.GetOptions{},
+						)
+						if err != nil {
+							tl.Fatalf("Error get sa secret %s: %v", saSecretName, err)
+						}
+						if secret.Type == corev1.SecretTypeServiceAccountToken {
+							if err := client.CoreV1().Secrets(joiningNamespace).Delete(context.TODO(), saSecretName, metav1.DeleteOptions{}); err != nil {
+								tl.Fatalf("Error delete secret %s: %v", secretName, err)
+							}
+						}
+					}
+				})
+				for _, objReference := range sa.Secrets {
+					saSecretName := objReference.Name
+					secret, err := client.CoreV1().Secrets(joiningNamespace).Get(
+						context.Background(), saSecretName, metav1.GetOptions{},
+					)
+					if err != nil {
+						return false, nil
+					}
+					if secret.Type == corev1.SecretTypeServiceAccountToken {
+						klog.V(2).Infof("Using secret named: %s", secret.Name)
+						return true, nil
+					}
+				}
+				return false, nil
+			})
+
+			// rejoin cluster, and secret change
+			_, errReJoinAfterChange := kubefedctl.TestOnlyJoinClusterForNamespace(
 				hostConfig, hostConfig, hostNamespace,
 				joiningNamespace, hostCluster, memberCluster,
 				secretName, apiextv1.NamespaceScoped, false, false)
@@ -133,10 +191,14 @@ var _ = Describe("Simulated Scale", func() {
 			defer func() {
 				framework.DeleteNamespace(client, joiningNamespace)
 			}()
-			if err != nil {
+			if errJoin != nil {
 				tl.Fatalf("Error joining cluster %s: %v", memberCluster, err)
 			}
 			if errReJoin != nil {
+				tl.Fatalf("Error joining cluster %s: %v", memberCluster, err)
+			}
+
+			if errReJoinAfterChange != nil {
 				tl.Fatalf("Error joining cluster %s: %v", memberCluster, err)
 			}
 		}
@@ -147,7 +209,7 @@ var _ = Describe("Simulated Scale", func() {
 			joiningNamespace := memberCluster
 			secretName := memberCluster
 
-			_, err := kubefedctl.TestOnlyJoinClusterForNamespace(
+			_, errJoin := kubefedctl.TestOnlyJoinClusterForNamespace(
 				hostConfig, hostConfig, hostNamespace,
 				joiningNamespace, hostCluster, memberCluster,
 				secretName, apiextv1.NamespaceScoped, false, true)
@@ -157,7 +219,7 @@ var _ = Describe("Simulated Scale", func() {
 				joiningNamespace, hostCluster, memberCluster,
 				secretName, apiextv1.NamespaceScoped, false, true)
 
-			if err != nil {
+			if errJoin != nil {
 				tl.Fatalf("Error joining cluster %s: %v", memberCluster, err)
 			}
 

--- a/test/e2e/scale.go
+++ b/test/e2e/scale.go
@@ -19,12 +19,14 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 	"strings"
+
+	"k8s.io/klog/v2"
 
 	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/kubefed/pkg/apis/core/typeconfig"
 	fedv1b1 "sigs.k8s.io/kubefed/pkg/apis/core/v1beta1"
 	genericclient "sigs.k8s.io/kubefed/pkg/client/generic"
@@ -116,7 +118,6 @@ var _ = Describe("Simulated Scale", func() {
 			memberCluster := fmt.Sprintf("scale-member-rejoin-%d-%s", i, nameToken)
 			memberClusters = append(memberClusters, memberCluster)
 			joiningNamespace := memberCluster
-
 			secretName := memberCluster
 
 			_, err := kubefedctl.TestOnlyJoinClusterForNamespace(
@@ -142,6 +143,7 @@ var _ = Describe("Simulated Scale", func() {
 		// rejoin errorOnExisting=true
 		for i := 0; i < framework.TestContext.ScaleClusterCount; i++ {
 			memberCluster := fmt.Sprintf("scale-member-rejoin-erroronexisting-%d-%s", i, nameToken)
+			memberClusters = append(memberClusters, memberCluster)
 			joiningNamespace := memberCluster
 			secretName := memberCluster
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

When use kubefedctl join cluster setting `error-on-existing=false` and `secret-name` have specify value, it will case secret exist error.  Join command demo:

```shell
kubefedctl join newdev --cluster-context newdev --host-cluster-context minikube --kubefed-namespace tpaas-federation --secret-name=minikube-newdev --error-on-existing=false -v 2
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
