### PR TITLE
Migrate pkg/scheduler logs to structured logging

### DIFF
--- a/pkg/controller/util/federated_informer.go
+++ b/pkg/controller/util/federated_informer.go
@@ -205,12 +205,12 @@ func NewFederatedInformer(
 					klog.Errorf("Cluster %v/%v not added; incorrect type", curCluster.Namespace, curCluster.Name)
 				case IsClusterReady(&curCluster.Status):
 					federatedInformer.addCluster(curCluster)
-					klog.Infof("Cluster %v/%v is ready", curCluster.Namespace, curCluster.Name)
+					klog.InfoS("Cluster is ready", "namespace", curCluster.Namespace, "cluster", curCluster.Name)
 					if clusterLifecycle.ClusterAvailable != nil {
 						clusterLifecycle.ClusterAvailable(curCluster)
 					}
 				default:
-					klog.Infof("Cluster %v/%v not added; it is not ready.", curCluster.Namespace, curCluster.Name)
+					klog.InfoS("Cluster not added; it is not ready.", "namespace", curCluster.Namespace, "cluster", curCluster.Name)
 				}
 			},
 			UpdateFunc: func(old, cur interface{}) {


### PR DESCRIPTION
**Migrate to structured logs**
### file modified:
pkg/controller/util/federated_informer.go
**What type of PR is this?**
/kind cleanup
### What this PR does / why we need it:
[Migrate unstructured logs to structured logs accoriding to](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/migration-to-structured-logging.md)
Which issue(s) this PR fixes:

Fixes #
pkg/controller/util/federated_informer.go
