### PR TITLE
retain healthCheckNodePort for service when updating

### DIFF
--- a/pkg/controller/sync/dispatch/retain.go
+++ b/pkg/controller/sync/dispatch/retain.go
@@ -46,6 +46,17 @@ func RetainClusterFields(targetKind string, desiredObj, clusterObj, fedObj *unst
 }
 
 func retainServiceFields(desiredObj, clusterObj *unstructured.Unstructured) error {
+	// healthCheckNodePort is allocated by APIServer and unchangeable, so it should be retained while updating
+	healthCheckNodePort, ok, err := unstructured.NestedInt64(clusterObj.Object, "spec", "healthCheckNodePort")
+	if err != nil {
+		return errors.Wrap(err, "Error retrieving healthCheckNodePort from service")
+	}
+	if ok && healthCheckNodePort > 0 {
+		if err = unstructured.SetNestedField(desiredObj.Object, healthCheckNodePort, "spec", "healthCheckNodePort"); err != nil {
+			return errors.Wrap(err, "Error setting healthCheckNodePort for service")
+		}
+	}
+
 	// ClusterIP and NodePort are allocated to Service by cluster, so retain the same if any while updating
 
 	// Retain clusterip


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
For services which type==LoadBalancer and externalTrafficPolicy==Local, their field `spec.healthCheckNodePort` will be allocated by APIServer, and after that it should be unchangeable, so we should retain this field during update, just like `spec.clusterIP` and `nodePort` in ports.

Here we don't need to check whether the desired service need `healthCheckNodePort` but just pass it on, because if the passed `healthCheckNodePort` is not needed any more, it will be recycled by APIServer.

**Special notes for your reviewer**:
Codes in kubernetes about the validation on `spec.healthCheckNodePort`, [https://github.com/kubernetes/kubernetes/blob/68108c70e29a74bb455ab63adeb5725a37e94e4f/pkg/registry/core/service/storage/rest.go#L369](https://github.com/kubernetes/kubernetes/blob/68108c70e29a74bb455ab63adeb5725a37e94e4f/pkg/registry/core/service/storage/rest.go#L369)
