### PR TITLE
Feature: support DeleteOptions when deleting resources in member clusters 

### DIFF
--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -31,7 +31,7 @@ type Client interface {
 	Create(ctx context.Context, obj runtime.Object) error
 	Get(ctx context.Context, obj runtime.Object, namespace, name string) error
 	Update(ctx context.Context, obj runtime.Object) error
-	Delete(ctx context.Context, obj runtime.Object, namespace, name string) error
+	Delete(ctx context.Context, obj runtime.Object, namespace, name string, opts ...client.DeleteOption) error
 	List(ctx context.Context, obj runtime.Object, namespace string, opts ...client.ListOption) error
 	UpdateStatus(ctx context.Context, obj runtime.Object) error
 }
@@ -71,14 +71,14 @@ func (c *genericClient) Update(ctx context.Context, obj runtime.Object) error {
 	return c.client.Update(ctx, obj)
 }
 
-func (c *genericClient) Delete(ctx context.Context, obj runtime.Object, namespace, name string) error {
+func (c *genericClient) Delete(ctx context.Context, obj runtime.Object, namespace, name string, opts ...client.DeleteOption) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return err
 	}
 	accessor.SetNamespace(namespace)
 	accessor.SetName(name)
-	return c.client.Delete(ctx, obj)
+	return c.client.Delete(ctx, obj, opts...)
 }
 
 func (c *genericClient) List(ctx context.Context, obj runtime.Object, namespace string, opts ...client.ListOption) error {

--- a/pkg/controller/sync/dispatch/managed.go
+++ b/pkg/controller/sync/dispatch/managed.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"sigs.k8s.io/kubefed/pkg/client/generic"
 	"sigs.k8s.io/kubefed/pkg/controller/sync/status"
 	"sigs.k8s.io/kubefed/pkg/controller/util"
@@ -245,10 +247,10 @@ func (d *managedDispatcherImpl) Update(clusterName string, clusterObj *unstructu
 	})
 }
 
-func (d *managedDispatcherImpl) Delete(clusterName string) {
+func (d *managedDispatcherImpl) Delete(clusterName string, opts ...client.DeleteOption) {
 	d.RecordStatus(clusterName, status.DeletionTimedOut, nil)
 
-	d.unmanagedDispatcher.Delete(clusterName)
+	d.unmanagedDispatcher.Delete(clusterName, opts...)
 }
 
 func (d *managedDispatcherImpl) RemoveManagedLabel(clusterName string, clusterObj *unstructured.Unstructured) {

--- a/pkg/controller/util/deletionannotation.go
+++ b/pkg/controller/util/deletionannotation.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// DeleteOptionAnnotation contains options for delete
+	// while deleting resources for member clusters.
+	DeleteOptionAnnotation = "kubefed.io/deleteoption"
+)
+
+// GetDeleteOptions return delete options from the annotation
+func GetDeleteOptions(obj *unstructured.Unstructured) ([]client.DeleteOption, error) {
+	options := make([]client.DeleteOption, 0)
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		return options, nil
+	}
+
+	if optStr, ok := annotations[DeleteOptionAnnotation]; ok {
+		opt := &metav1.DeleteOptions{}
+		if err := json.Unmarshal([]byte(optStr), opt); err != nil {
+			return nil, errors.Wrapf(err, "could not deserialize delete options from annotation value '%s'", optStr)
+		}
+		clientOpt := &client.DeleteOptions{}
+		clientOpt.GracePeriodSeconds = opt.GracePeriodSeconds
+		clientOpt.PropagationPolicy = opt.PropagationPolicy
+		clientOpt.Preconditions = opt.Preconditions
+		options = append(options, clientOpt)
+	}
+	return options, nil
+}
+
+// ApplyDeleteOptions set the DeleteOptions on the annotation
+func ApplyDeleteOptions(obj *unstructured.Unstructured, opts ...client.DeleteOption) {
+	opt := client.DeleteOptions{}
+	opt.ApplyOptions(opts)
+
+	if optBytes, err := json.Marshal(opt.AsDeleteOptions()); err == nil {
+		annotations := obj.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[DeleteOptionAnnotation] = string(optBytes)
+		obj.SetAnnotations(annotations)
+	}
+}

--- a/pkg/controller/util/deletionannotation.go
+++ b/pkg/controller/util/deletionannotation.go
@@ -54,16 +54,20 @@ func GetDeleteOptions(obj *unstructured.Unstructured) ([]client.DeleteOption, er
 }
 
 // ApplyDeleteOptions set the DeleteOptions on the annotation
-func ApplyDeleteOptions(obj *unstructured.Unstructured, opts ...client.DeleteOption) {
+func ApplyDeleteOptions(obj *unstructured.Unstructured, opts ...client.DeleteOption) error {
 	opt := client.DeleteOptions{}
 	opt.ApplyOptions(opts)
-
-	if optBytes, err := json.Marshal(opt.AsDeleteOptions()); err == nil {
-		annotations := obj.GetAnnotations()
-		if annotations == nil {
-			annotations = make(map[string]string)
-		}
-		annotations[DeleteOptionAnnotation] = string(optBytes)
-		obj.SetAnnotations(annotations)
+	deleteOpts := opt.AsDeleteOptions()
+	optBytes, err := json.Marshal(deleteOpts)
+	if err != nil {
+		return errors.Wrapf(err, "could not serialize delete options from object '%v'", deleteOpts)
 	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[DeleteOptionAnnotation] = string(optBytes)
+	obj.SetAnnotations(annotations)
+	return nil
 }

--- a/pkg/controller/util/deletionannotation_test.go
+++ b/pkg/controller/util/deletionannotation_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestDeleteOptions(t *testing.T) {
+	fedObj := &unstructured.Unstructured{}
+
+	fedObjOrphan := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					DeleteOptionAnnotation: "{\"propagationPolicy\":\"Orphan\"}",
+				},
+			},
+		},
+	}
+
+	fedObjGrace := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					DeleteOptionAnnotation: "{\"gracePeriodSeconds\":5}",
+				},
+			},
+		},
+	}
+
+	fedObjGraceAndOrphan := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					DeleteOptionAnnotation: "{\"propagationPolicy\":\"Orphan\",\"gracePeriodSeconds\":5}",
+				},
+			},
+		},
+	}
+
+	actOpt0 := client.DeleteOptions{}
+	opt0, _ := GetDeleteOptions(fedObj)
+	actOpt0.ApplyOptions(opt0)
+	expOpt0 := client.DeleteOptions{}
+	assert.Equal(t, expOpt0.AsDeleteOptions(), actOpt0.AsDeleteOptions())
+
+	actOpt1 := client.DeleteOptions{}
+	opt1, _ := GetDeleteOptions(fedObjOrphan)
+	actOpt1.ApplyOptions(opt1)
+	prop := metav1.DeletePropagationOrphan
+	expOpt1 := client.DeleteOptions{PropagationPolicy: &prop}
+	assert.Equal(t, expOpt1.AsDeleteOptions(), actOpt1.AsDeleteOptions())
+
+	actOpt2 := client.DeleteOptions{}
+	opt2, _ := GetDeleteOptions(fedObjGrace)
+	actOpt2.ApplyOptions(opt2)
+	seconds := int64(5)
+	expOpt2 := client.DeleteOptions{GracePeriodSeconds: &seconds}
+	assert.Equal(t, expOpt2.AsDeleteOptions(), actOpt2.AsDeleteOptions())
+
+	actOpt3 := client.DeleteOptions{}
+	opt3, _ := GetDeleteOptions(fedObjGraceAndOrphan)
+	actOpt3.ApplyOptions(opt3)
+	expOpt3 := client.DeleteOptions{GracePeriodSeconds: &seconds, PropagationPolicy: &prop}
+	assert.Equal(t, expOpt3.AsDeleteOptions(), actOpt3.AsDeleteOptions())
+}

--- a/test/e2e/deleteoptions.go
+++ b/test/e2e/deleteoptions.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	. "github.com/onsi/ginkgo" //nolint:stylecheck
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/kubefed/test/common"
+	"sigs.k8s.io/kubefed/test/e2e/framework"
+)
+
+var typeConfigName = "deployments.apps"
+
+var _ = Describe("DeleteOptions", func() {
+	f := framework.NewKubeFedFramework("delete-options")
+
+	tl := framework.NewE2ELogger()
+
+	typeConfigFixtures := common.TypeConfigFixturesOrDie(tl)
+
+	fixture := typeConfigFixtures[typeConfigName]
+
+	It("Deployment should be created and deleted successfully, but ReplicaSet that created by Deployment won't be deleted", func() {
+
+		typeConfig, testObjectsFunc := getCrudTestInput(f, tl, typeConfigName, fixture)
+		crudTester, targetObject, overrides := initCrudTest(f, tl, typeConfig, testObjectsFunc)
+		fedObject := crudTester.CheckCreate(targetObject, overrides)
+
+		By("Set PropagationPolicy property as 'Orphan' on the DeleteOptions for Federated Deployment")
+		orphan := metav1.DeletePropagationOrphan
+		prop := client.PropagationPolicy(orphan)
+
+		crudTester.SetDeleteOption(fedObject, prop)
+
+		crudTester.CheckDelete(fedObject, false)
+
+		By("Checking ReplicatSet stutus for every cluster")
+		crudTester.CheckReplicaSet(targetObject)
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements PR #1348 to support DeleteOptions when deleting resources in member clusters.  When deleting a federated resource with `kubefed.io/deleteoptions` annotation, it will be deserialized as a DeleteOptons object and apply to the delete operation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1348


