### PR TITLE
kubefedcluster use cadata in kubeconfig file

### DIFF
--- a/docs/cluster-registration.md
+++ b/docs/cluster-registration.md
@@ -25,6 +25,7 @@ Repeat this step to join any additional clusters.
 
 **NOTE:** `cluster-context` will default to use the joining cluster name if not
 specified.
+**NOTE:** Before the [PR](https://github.com/kubernetes-sigs/kubefed/pull/1361), `kubefed` automatically fetches apiserver's `certificate-authority-data` from member cluster, after that kubefed will use `certificate-authority-data` in joining cluster's kubeconfig file.
 
 # Checking status of joined clusters
 

--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -272,6 +272,10 @@ func joinClusterForNamespace(hostConfig, clusterConfig *rest.Config, kubefedName
 		disabledTLSValidations = append(disabledTLSValidations, fedv1b1.TLSAll)
 	}
 
+	if clusterConfig.CAData != nil {
+		caBundle = clusterConfig.CAData
+	}
+
 	kubefedCluster, err := createKubeFedCluster(client, joiningClusterName, clusterConfig.Host,
 		secret.Name, kubefedNamespace, caBundle, disabledTLSValidations, dryRun, errorOnExisting)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Kubefedcluster's cadata build from member cluster's serviceaccount, it work well when kubefed directlly conntect to member cluster. In my case, kubefed connect to a proxyserver (it proxy all apiserver's traffic), and the proxyserver has a independent cabundle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
