### PR TITLE
enable workqueue metrics for all controllers

### DIFF
--- a/pkg/controller/federatedtypeconfig/controller.go
+++ b/pkg/controller/federatedtypeconfig/controller.go
@@ -90,7 +90,7 @@ func newController(config *util.ControllerConfig) (*Controller, error) {
 		stopChannels:     make(map[string]chan struct{}),
 	}
 
-	c.worker = util.NewReconcileWorker(c.reconcile, util.WorkerTiming{})
+	c.worker = util.NewReconcileWorker("federatedtypeconfig", c.reconcile, util.WorkerTiming{})
 
 	// Only watch the KubeFed namespace to ensure
 	// restrictive authz can be applied to a namespaced

--- a/pkg/controller/schedulingmanager/controller.go
+++ b/pkg/controller/schedulingmanager/controller.go
@@ -92,7 +92,7 @@ func newSchedulingManager(config *util.ControllerConfig) (*SchedulingManager, er
 		schedulers: util.NewSafeMap(),
 	}
 
-	c.worker = util.NewReconcileWorker(c.reconcile, util.WorkerTiming{})
+	c.worker = util.NewReconcileWorker("schedulingmanager", c.reconcile, util.WorkerTiming{})
 
 	var err error
 	c.store, c.controller, err = util.NewGenericInformer(

--- a/pkg/controller/schedulingpreference/controller.go
+++ b/pkg/controller/schedulingpreference/controller.go
@@ -18,6 +18,7 @@ package schedulingpreference
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -104,7 +105,7 @@ func newSchedulingPreferenceController(config *util.ControllerConfig, scheduling
 		eventRecorder:           recorder,
 	}
 
-	s.worker = util.NewReconcileWorker(s.reconcile, util.WorkerTiming{
+	s.worker = util.NewReconcileWorker(strings.ToLower(schedulingType.Kind), s.reconcile, util.WorkerTiming{
 		ClusterSyncDelay: s.clusterAvailableDelay,
 	})
 

--- a/pkg/controller/status/controller.go
+++ b/pkg/controller/status/controller.go
@@ -123,7 +123,7 @@ func newKubeFedStatusController(controllerConfig *util.ControllerConfig, typeCon
 		fedNamespace:            controllerConfig.KubeFedNamespace,
 	}
 
-	s.worker = util.NewReconcileWorker(s.reconcile, util.WorkerTiming{
+	s.worker = util.NewReconcileWorker(strings.ToLower(statusAPIResource.Kind), s.reconcile, util.WorkerTiming{
 		ClusterSyncDelay: s.clusterAvailableDelay,
 	})
 

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -132,7 +132,7 @@ func newKubeFedSyncController(controllerConfig *util.ControllerConfig, typeConfi
 		rawResourceStatusCollection: controllerConfig.RawResourceStatusCollection,
 	}
 
-	s.worker = util.NewReconcileWorker(s.reconcile, util.WorkerTiming{
+	s.worker = util.NewReconcileWorker(strings.ToLower(federatedTypeAPIResource.Kind), s.reconcile, util.WorkerTiming{
 		ClusterSyncDelay: s.clusterAvailableDelay,
 	})
 

--- a/pkg/controller/util/worker.go
+++ b/pkg/controller/util/worker.go
@@ -47,6 +47,8 @@ type WorkerTiming struct {
 }
 
 type asyncWorker struct {
+	name string
+
 	reconcile ReconcileFunc
 
 	timing WorkerTiming
@@ -64,7 +66,7 @@ type asyncWorker struct {
 	backoff *flowcontrol.Backoff
 }
 
-func NewReconcileWorker(reconcile ReconcileFunc, timing WorkerTiming) ReconcileWorker {
+func NewReconcileWorker(name string, reconcile ReconcileFunc, timing WorkerTiming) ReconcileWorker {
 	if timing.Interval == 0 {
 		timing.Interval = time.Second * 1
 	}
@@ -78,10 +80,11 @@ func NewReconcileWorker(reconcile ReconcileFunc, timing WorkerTiming) ReconcileW
 		timing.MaxBackoff = time.Minute
 	}
 	return &asyncWorker{
+		name:      name,
 		reconcile: reconcile,
 		timing:    timing,
 		deliverer: NewDelayingDeliverer(),
-		queue:     workqueue.New(),
+		queue:     workqueue.NewNamed(name),
 		backoff:   flowcontrol.NewBackOff(timing.InitialBackoff, timing.MaxBackoff),
 	}
 }


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR will help to enable workqueue metrics for all controllers.
Client-go has implemented [a built-in metrics](https://github.com/kubernetes/client-go/blob/fa8f4cc307b81b125f6beb2cea6f093ed9e3c069/util/workqueue/metrics.go#L72-L90), but it will be disabled when created workqueue is nameless [https://github.com/kubernetes/client-go/blob/fa8f4cc307b81b125f6beb2cea6f093ed9e3c069/util/workqueue/metrics.go#L231](https://github.com/kubernetes/client-go/blob/fa8f4cc307b81b125f6beb2cea6f093ed9e3c069/util/workqueue/metrics.go#L231) .
So this pr is trying to assign a unique name for each controller(workqueue), and this name is usually **the lowercase singular kind** which is being reconciled by this controller.

**Special notes for your reviewer**:
`NONE`
