### PR TITLE
Infinite reconciliation loop rawstatuscollection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/go-logr/zapr v0.2.0 // indirect
+	github.com/google/go-cmp v0.5.2
 	github.com/json-iterator/go v1.1.10
 	github.com/onsi/ginkgo v1.14.2
 	github.com/onsi/gomega v1.10.3

--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -293,6 +293,7 @@ func (s *KubeFedSyncController) syncToClusters(fedResource FederatedResource) ut
 	// Enable raw resource status collection if the statusCollection is enabled for that type
 	// and the feature is also enabled.
 	enableRawResourceStatusCollection := s.typeConfig.GetStatusEnabled() && s.rawResourceStatusCollection
+	klog.V(4).Infof("typeconfigstatus for %v enabled: %v, rawresstatus: %v", fedResource.FederatedName(), s.typeConfig.GetStatusEnabled(), enableRawResourceStatusCollection)
 
 	clusters, err := s.informer.GetClusters()
 	if err != nil {
@@ -387,7 +388,8 @@ func (s *KubeFedSyncController) syncToClusters(fedResource FederatedResource) ut
 	}
 
 	collectedStatus, collectedResourceStatus := dispatcher.CollectedStatus()
-	klog.V(4).Infof("Setting the federated status '%v'", collectedResourceStatus)
+	klog.V(4).Infof("Setting the federated status '%v' for %s %q", collectedResourceStatus, kind, key)
+	klog.V(4).Infof("Collected status '%v' for %s %q", collectedStatus, kind, key)
 	return s.setFederatedStatus(fedResource, status.AggregateSuccess, &collectedStatus, &collectedResourceStatus, enableRawResourceStatusCollection)
 }
 

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -177,7 +177,7 @@ func (s *GenericFederatedStatus) update(generation int64, reason AggregateReason
 		}
 	}
 
-	clustersChanged := s.setClusters(collectedStatus.StatusMap, collectedResourceStatus.StatusMap)
+	clustersChanged := s.setClusters(collectedStatus.StatusMap, collectedResourceStatus.StatusMap, resourceStatusCollection)
 
 	// Indicate that changes were propagated if either status.clusters
 	// was changed or if existing resources were updated (which could
@@ -196,8 +196,8 @@ func (s *GenericFederatedStatus) update(generation int64, reason AggregateReason
 // setClusters sets the status.clusters slice from propagation and resource status
 // maps. Returns a boolean indication of whether the status.clusters was
 // modified.
-func (s *GenericFederatedStatus) setClusters(statusMap PropagationStatusMap, resourceStatusMap map[string]interface{}) bool {
-	if !s.clustersDiffer(statusMap, resourceStatusMap) {
+func (s *GenericFederatedStatus) setClusters(statusMap PropagationStatusMap, resourceStatusMap map[string]interface{}, resourceStatusCollection bool) bool {
+	if !s.clustersDiffer(statusMap, resourceStatusMap, resourceStatusCollection) {
 		return false
 	}
 	s.Clusters = []GenericClusterStatus{}
@@ -214,9 +214,9 @@ func (s *GenericFederatedStatus) setClusters(statusMap PropagationStatusMap, res
 
 // clustersDiffer checks whether `status.clusters` differs from the
 // given status map.
-func (s *GenericFederatedStatus) clustersDiffer(statusMap PropagationStatusMap, resourceStatusMap map[string]interface{}) bool {
-	if len(s.Clusters) != len(statusMap) || len(s.Clusters) != len(resourceStatusMap) {
-		klog.V(4).Info("Clusters differs from the size")
+func (s *GenericFederatedStatus) clustersDiffer(statusMap PropagationStatusMap, resourceStatusMap map[string]interface{}, resourceStatusCollection bool) bool {
+	if len(s.Clusters) != len(statusMap) || resourceStatusCollection && (len(s.Clusters) != len(resourceStatusMap)) {
+		klog.V(4).Infof("Clusters differs from the size: clusters = %v, statusMap = %v, resourceStatusMap = %v", s.Clusters, statusMap, resourceStatusMap )
 		return true
 	}
 	for _, status := range s.Clusters {

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -28,6 +28,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 		reason            AggregateReason
 		statusMap         PropagationStatusMap
 		resourceStatusMap map[string]interface{}
+		remoteStatus interface{}
 		resourcesUpdated  bool
 		expectedChanged   bool
 		resourceStatusCollection bool
@@ -82,17 +83,46 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusCollection: false,
 			expectedChanged:  true,
 		},
-		//"No change in clusters indicates unchanged": {
-		//	statusMap: PropagationStatusMap{
-		//		"cluster1": ClusterPropagationOK,
-		//	},
-		//	resourceStatusMap: map[string]interface{}{
-		//		"cluster1": map[string]interface{}{},
-		//	},
-		//	resourcesUpdated: false,
-		//	resourceStatusCollection: true,
-		//	expectedChanged:  true,
-		//},
+		"No collected remote status indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			reason: AggregateSuccess,
+			resourcesUpdated: false,
+			resourceStatusCollection: true,
+			expectedChanged:  true,
+		},
+		"No collected remote status indicates unchanged with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			reason: AggregateSuccess,
+			resourcesUpdated: false,
+			resourceStatusCollection: false,
+			expectedChanged:  false,
+		},
+		"No change in clusters indicates unchanged with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			resourcesUpdated: false,
+			resourceStatusCollection: true,
+			expectedChanged:  true,
+		},
+		"No change in clusters indicates unchanged with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			resourcesUpdated: false,
+			resourceStatusCollection: false,
+			expectedChanged:  true,
+		},
 		//"No change in clusters with update indicates changed": {
 		//	statusMap: PropagationStatusMap{
 		//		"cluster1": ClusterPropagationOK,
@@ -142,7 +172,8 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			fedStatus := &GenericFederatedStatus{
 				Clusters: []GenericClusterStatus{
 					{
-						Name: "cluster1",
+						Name:         "cluster1",
+						RemoteStatus: tc.remoteStatus,
 					},
 				},
 				Conditions: []*GenericCondition{

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -58,26 +58,14 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			expectedChanged:  true,
 		},
 		"Cluster status not retrieved indicates changed with status collected enabled": {
-			statusMap: PropagationStatusMap{
-				"cluster1": ClusterPropagationOK,
-				"cluster2": ClusterPropagationOK,
-			},
-			resourceStatusMap: map[string]interface{}{
-				"cluster1": map[string]interface{}{},
-			},
+			statusMap: PropagationStatusMap{},
 			reason: AggregateSuccess,
 			resourcesUpdated: false,
 			resourceStatusCollection: true,
 			expectedChanged:  true,
 		},
 		"Cluster status not retrieved indicates changed with status collected disabled": {
-			statusMap: PropagationStatusMap{
-				"cluster1": ClusterPropagationOK,
-				"cluster2": ClusterPropagationOK,
-			},
-			resourceStatusMap: map[string]interface{}{
-				"cluster1": map[string]interface{}{},
-			},
+			statusMap: PropagationStatusMap{},
 			reason: AggregateSuccess,
 			resourcesUpdated: false,
 			resourceStatusCollection: false,
@@ -145,17 +133,22 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusCollection: false,
 			expectedChanged:  true,
 		},
-		//"Change in clusters indicates changed": {
-		//	statusMap: PropagationStatusMap{
-		//		"cluster1": ClusterPropagationOK,
-		//	},
-		//	resourceStatusMap: map[string]interface{}{
-		//		"ready": true,
-		//		"stage": "deployed",
-		//	},
-		//	resourceStatusCollection: true,
-		//	expectedChanged: true,
-		//},
+		"Change in clusters indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+				"cluster2": ClusterPropagationOK,
+			},
+			resourceStatusCollection: true,
+			expectedChanged: true,
+		},
+		"Change in clusters indicates changed with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+				"cluster2": ClusterPropagationOK,
+			},
+			resourceStatusCollection: false,
+			expectedChanged: true,
+		},
 		"Transition indicates changed with remote status collection enabled": {
 			reason:          NamespaceNotFederated,
 			resourceStatusCollection: true,

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -123,18 +123,28 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusCollection: false,
 			expectedChanged:  true,
 		},
-		//"No change in clusters with update indicates changed": {
-		//	statusMap: PropagationStatusMap{
-		//		"cluster1": ClusterPropagationOK,
-		//	},
-		//	resourceStatusMap: map[string]interface{}{
-		//		"ready": false,
-		//		"stage": "absent",
-		//	},
-		//	resourcesUpdated: true,
-		//	resourceStatusCollection: true,
-		//	expectedChanged:  true,
-		//},
+		"No change in clusters with update indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			resourcesUpdated: true,
+			resourceStatusCollection: true,
+			expectedChanged:  true,
+		},
+		"No change in clusters with update indicates changed with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			resourcesUpdated: true,
+			resourceStatusCollection: false,
+			expectedChanged:  true,
+		},
 		//"Change in clusters indicates changed": {
 		//	statusMap: PropagationStatusMap{
 		//		"cluster1": ClusterPropagationOK,
@@ -146,26 +156,26 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 		//	resourceStatusCollection: true,
 		//	expectedChanged: true,
 		//},
-		//"Transition indicates changed with remote status collection enabled": {
-		//	reason:          NamespaceNotFederated,
-		//	resourceStatusCollection: true,
-		//	expectedChanged: true,
-		//},
-		//"Transition indicates changed with remote status collection disabled": {
-		//	reason:          NamespaceNotFederated,
-		//	resourceStatusCollection: false,
-		//	expectedChanged: true,
-		//},
-		//"Changed generation indicates changed with remote status collection enabled": {
-		//	generation:      1,
-		//	resourceStatusCollection: true,
-		//	expectedChanged: true,
-		//},
-		//"Changed generation indicates changed with remote status collection disabled": {
-		//	generation:      1,
-		//	resourceStatusCollection: false,
-		//	expectedChanged: true,
-		//},
+		"Transition indicates changed with remote status collection enabled": {
+			reason:          NamespaceNotFederated,
+			resourceStatusCollection: true,
+			expectedChanged: true,
+		},
+		"Transition indicates changed with remote status collection disabled": {
+			reason:          NamespaceNotFederated,
+			resourceStatusCollection: false,
+			expectedChanged: true,
+		},
+		"Changed generation indicates changed with remote status collection enabled": {
+			generation:      1,
+			resourceStatusCollection: true,
+			expectedChanged: true,
+		},
+		"Changed generation indicates changed with remote status collection disabled": {
+			generation:      1,
+			resourceStatusCollection: false,
+			expectedChanged: true,
+		},
 	}
 	for testName, tc := range testCases {
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -24,13 +24,13 @@ import (
 
 func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 	testCases := map[string]struct {
-		generation        int64
-		reason            AggregateReason
-		statusMap         PropagationStatusMap
-		resourceStatusMap map[string]interface{}
-		remoteStatus interface{}
-		resourcesUpdated  bool
-		expectedChanged   bool
+		generation               int64
+		reason                   AggregateReason
+		statusMap                PropagationStatusMap
+		resourceStatusMap        map[string]interface{}
+		remoteStatus             interface{}
+		resourcesUpdated         bool
+		expectedChanged          bool
 		resourceStatusCollection bool
 	}{
 		"Cluster not propagated indicates changed with status collected enabled": {
@@ -40,10 +40,10 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: true,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"Cluster not propagated indicates changed with status collected disabled": {
 			statusMap: PropagationStatusMap{
@@ -52,42 +52,42 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: false,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"Cluster status not retrieved indicates changed with status collected enabled": {
-			statusMap: PropagationStatusMap{},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			statusMap:                PropagationStatusMap{},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: true,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"Cluster status not retrieved indicates changed with status collected disabled": {
-			statusMap: PropagationStatusMap{},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			statusMap:                PropagationStatusMap{},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: false,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"No collected remote status indicates changed with status collected enabled": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: true,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"No collected remote status indicates unchanged with status collected disabled": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
-			reason: AggregateSuccess,
-			resourcesUpdated: false,
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
 			resourceStatusCollection: false,
-			expectedChanged:  false,
+			expectedChanged:          false,
 		},
 		"No change in clusters indicates unchanged with status collected enabled": {
 			statusMap: PropagationStatusMap{
@@ -96,9 +96,9 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: false,
+			resourcesUpdated:         false,
 			resourceStatusCollection: true,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"No change in clusters indicates unchanged with status collected disabled": {
 			statusMap: PropagationStatusMap{
@@ -107,9 +107,9 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: false,
+			resourcesUpdated:         false,
 			resourceStatusCollection: false,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"No change in clusters with update indicates changed with status collected enabled": {
 			statusMap: PropagationStatusMap{
@@ -118,9 +118,9 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: true,
+			resourcesUpdated:         true,
 			resourceStatusCollection: true,
-			expectedChanged:  true,
+			expectedChanged:          true,
 		},
 		"No change in clusters with update indicates changed with status collected disabled": {
 			statusMap: PropagationStatusMap{
@@ -129,9 +129,29 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			resourceStatusMap: map[string]interface{}{
 				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: true,
+			resourcesUpdated:         true,
 			resourceStatusCollection: false,
-			expectedChanged:  true,
+			expectedChanged:          true,
+		},
+		"No change in remote status indicates unchanged with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{
+					"status": map[string]interface{}{
+						"status": "remoteStatus",
+					},
+				},
+			},
+			remoteStatus: map[string]interface{}{
+				"status": map[string]interface{}{
+					"status": "remoteStatus",
+				},
+			},
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          false,
 		},
 		"Change in clusters indicates changed with status collected enabled": {
 			statusMap: PropagationStatusMap{
@@ -139,7 +159,7 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				"cluster2": ClusterPropagationOK,
 			},
 			resourceStatusCollection: true,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 		"Change in clusters indicates changed with status collected disabled": {
 			statusMap: PropagationStatusMap{
@@ -147,27 +167,27 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				"cluster2": ClusterPropagationOK,
 			},
 			resourceStatusCollection: false,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 		"Transition indicates changed with remote status collection enabled": {
-			reason:          NamespaceNotFederated,
+			reason:                   NamespaceNotFederated,
 			resourceStatusCollection: true,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 		"Transition indicates changed with remote status collection disabled": {
-			reason:          NamespaceNotFederated,
+			reason:                   NamespaceNotFederated,
 			resourceStatusCollection: false,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 		"Changed generation indicates changed with remote status collection enabled": {
-			generation:      1,
+			generation:               1,
 			resourceStatusCollection: true,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 		"Changed generation indicates changed with remote status collection disabled": {
-			generation:      1,
+			generation:               1,
 			resourceStatusCollection: false,
-			expectedChanged: true,
+			expectedChanged:          true,
 		},
 	}
 	for testName, tc := range testCases {
@@ -201,4 +221,3 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 		})
 	}
 }
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Federated resources that have target resources without `status` field are constantly evaluated as "changed", if RawStatusCollection is Enabled. This triggers an infinite loop when multiple FederatedResources are created at the same time in the cluster

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1373

**Special notes for your reviewer**:
Draft PR, still working on the tests