### PR TITLE
make objects in workqueue "comparable" to avoid multiple reconciliations on one object at same time

### DIFF
--- a/pkg/controller/util/worker_test.go
+++ b/pkg/controller/util/worker_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestDeduplicate(t *testing.T) {
+	// single event for reconciliation
+	singleEvent := QualifiedName{
+		Namespace: "ns",
+		Name:      "name",
+	}
+
+	// counters for reconciliation and enqueue
+	var reconcileCount, enqueueCount int32 = 0, 0
+	addReconcileCount := func() {
+		atomic.AddInt32(&reconcileCount, 1)
+	}
+	addEnqueueCount := func() {
+		atomic.AddInt32(&enqueueCount, 1)
+	}
+
+	var worker ReconcileWorker
+
+	// an utility function to enqueue single event for specified times
+	duplicateEnqueue := func(times int) {
+		for i := 0; i < times; i++ {
+			worker.Enqueue(singleEvent)
+			addEnqueueCount()
+		}
+	}
+
+	// new worker
+	doOnce := sync.Once{}
+	worker = NewReconcileWorker("test deduplicate",
+		func(qualifiedName QualifiedName) ReconciliationStatus {
+			addReconcileCount()
+			// enqueue same events for 5 times during the reconciliation itself
+			doOnce.Do(func() {
+				duplicateEnqueue(5)
+			})
+			return StatusAllOK
+		},
+		WorkerTiming{},
+	)
+
+	// run worker
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	worker.Run(ctx.Done())
+
+	// enqueue single event for 10 times
+	duplicateEnqueue(10)
+
+	// wait for all events enqueued and reconciled
+	// FIXME: there is not a good way to detect whether all enqueued events have been reconciled, so we just wait for a while
+	time.Sleep(1 * time.Second)
+
+	// check counters
+	if enqueueCount != 15 {
+		t.Errorf("expected enqueue count 15 but got %d", enqueueCount)
+	}
+	if reconcileCount != 2 {
+		t.Errorf("expected reconcile count 2 but got %d", reconcileCount)
+	}
+
+	t.Logf("the enqueued (before or during reconciliation) 15 same events have been squashed to 2")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
As we know, `workqueue` is using a map [dirty map[interface{}]struct{}](https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/util/workqueue/queue.go#L78) to deduplicate objects and prevent same object(with same namespace and name) to be reconciled by multiple workers at same time.
This means that the objects enqueued must be *comparable*.
But kubefed is just enqueuing objects of type `*DelayingDelivererItem` which will never be equal (pointer values with different addresses), [https://github.com/kubernetes-sigs/kubefed/blob/16b2f5cc4f05c9e9b696970295f353c56d33aa3a/pkg/controller/util/worker.go#L119-L121](https://github.com/kubernetes-sigs/kubefed/blob/16b2f5cc4f05c9e9b696970295f353c56d33aa3a/pkg/controller/util/worker.go#L119-L121).
So, even `federatedTypeConfig` controller has [a global locker](https://github.com/kubernetes-sigs/kubefed/blob/16b2f5cc4f05c9e9b696970295f353c56d33aa3a/pkg/controller/federatedtypeconfig/controller.go#L54-L55) for sync/status controllers, sync/status controllers will still be initialized several times.

Here is a timeline,
1. `federatedService` reconciliation starts in worker1
2. add finalizer to `federatedService` brings an update event
3. `federatedService` reconciliation starts in worker2 (workqueue regards this as a new object because they are not equal)
4. worker1 checks sync controller map(not found) and create one
5. worker2 checks sync controller map(not found) and create another
6. worker1 fills the stop channel to map
7. worker2 fills another stop channel to map(the first created sync controller will lose control)
....


**Which issue(s) this PR fixes**:
Fixes #1375 

**Special notes for your reviewer**:
1. "comparable" here means objects should be identical and equal with same namespace and name
2. precheck (type cast) object type before enqueuing and after getting
3. move `reconcile logic` into a new function to call `Done` in defer for more returns

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>
