### PR TITLE
Infinite reconciliation loop (rawstatuscollection)

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -387,7 +387,7 @@ func (s *KubeFedSyncController) syncToClusters(fedResource FederatedResource) ut
 	}
 
 	collectedStatus, collectedResourceStatus := dispatcher.CollectedStatus()
-	klog.V(4).Infof("Setting the federated status '%v'", collectedResourceStatus)
+	klog.V(4).Infof("Setting the federated status '%v' for %s %q", collectedResourceStatus, kind, key)
 	return s.setFederatedStatus(fedResource, status.AggregateSuccess, &collectedStatus, &collectedResourceStatus, enableRawResourceStatusCollection)
 }
 

--- a/pkg/controller/sync/status/status_test.go
+++ b/pkg/controller/sync/status/status_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package status
 
 import (
+	"reflect"
 	"testing"
 
 	apiv1 "k8s.io/api/core/v1"
@@ -24,52 +25,170 @@ import (
 
 func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 	testCases := map[string]struct {
-		generation        int64
-		reason            AggregateReason
-		statusMap         PropagationStatusMap
-		resourceStatusMap map[string]interface{}
-		resourcesUpdated  bool
-		expectedChanged   bool
+		generation               int64
+		reason                   AggregateReason
+		statusMap                PropagationStatusMap
+		resourceStatusMap        map[string]interface{}
+		remoteStatus             interface{}
+		resourcesUpdated         bool
+		expectedChanged          bool
+		resourceStatusCollection bool
 	}{
-		"No change in clusters indicates unchanged": {
+		"Cluster not propagated indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterNotReady,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"Cluster not propagated indicates changed with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterNotReady,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
+		},
+		"Cluster status not retrieved indicates changed with status collected enabled": {
+			statusMap:                PropagationStatusMap{},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"Cluster status not retrieved indicates changed with status collected disabled": {
+			statusMap:                PropagationStatusMap{},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
+		},
+		"No collected remote status indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"No collected remote status indicates unchanged with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			reason:                   AggregateSuccess,
+			resourcesUpdated:         false,
+			resourceStatusCollection: false,
+			expectedChanged:          false,
+		},
+		"No change in clusters indicates unchanged with status collected enabled": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
 			resourceStatusMap: map[string]interface{}{
-				"ready": false,
-				"stage": "absent",
+				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: false,
-			expectedChanged:  true,
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
 		},
-		"No change in clusters with update indicates changed": {
+		"No change in clusters indicates unchanged with status collected disabled": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
 			resourceStatusMap: map[string]interface{}{
-				"ready": false,
-				"stage": "absent",
+				"cluster1": map[string]interface{}{},
 			},
-			resourcesUpdated: true,
-			expectedChanged:  true,
+			resourcesUpdated:         false,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
 		},
-		"Change in clusters indicates changed": {
+		"No change in clusters with update indicates changed with status collected enabled": {
 			statusMap: PropagationStatusMap{
 				"cluster1": ClusterPropagationOK,
 			},
 			resourceStatusMap: map[string]interface{}{
-				"ready": true,
-				"stage": "deployed",
+				"cluster1": map[string]interface{}{},
 			},
-			expectedChanged: true,
+			resourcesUpdated:         true,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
 		},
-		"Transition indicates changed": {
-			reason:          NamespaceNotFederated,
-			expectedChanged: true,
+		"No change in clusters with update indicates changed with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{},
+			},
+			resourcesUpdated:         true,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
 		},
-		"Changed generation indicates changed": {
-			generation:      1,
-			expectedChanged: true,
+		"No change in remote status indicates unchanged with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+			},
+			resourceStatusMap: map[string]interface{}{
+				"cluster1": map[string]interface{}{
+					"status": map[string]interface{}{
+						"status": "remoteStatus",
+					},
+				},
+			},
+			remoteStatus: map[string]interface{}{
+				"status": map[string]interface{}{
+					"status": "remoteStatus",
+				},
+			},
+			resourcesUpdated:         false,
+			resourceStatusCollection: true,
+			expectedChanged:          false,
+		},
+		"Change in clusters indicates changed with status collected enabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+				"cluster2": ClusterPropagationOK,
+			},
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"Change in clusters indicates changed with status collected disabled": {
+			statusMap: PropagationStatusMap{
+				"cluster1": ClusterPropagationOK,
+				"cluster2": ClusterPropagationOK,
+			},
+			resourceStatusCollection: false,
+			expectedChanged:          true,
+		},
+		"Transition indicates changed with remote status collection enabled": {
+			reason:                   NamespaceNotFederated,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"Transition indicates changed with remote status collection disabled": {
+			reason:                   NamespaceNotFederated,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
+		},
+		"Changed generation indicates changed with remote status collection enabled": {
+			generation:               1,
+			resourceStatusCollection: true,
+			expectedChanged:          true,
+		},
+		"Changed generation indicates changed with remote status collection disabled": {
+			generation:               1,
+			resourceStatusCollection: false,
+			expectedChanged:          true,
 		},
 	}
 	for testName, tc := range testCases {
@@ -77,7 +196,8 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 			fedStatus := &GenericFederatedStatus{
 				Clusters: []GenericClusterStatus{
 					{
-						Name: "cluster1",
+						Name:         "cluster1",
+						RemoteStatus: tc.remoteStatus,
 					},
 				},
 				Conditions: []*GenericCondition{
@@ -95,9 +215,67 @@ func TestGenericPropagationStatusUpdateChanged(t *testing.T) {
 				StatusMap:        tc.resourceStatusMap,
 				ResourcesUpdated: tc.resourcesUpdated,
 			}
-			changed := fedStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus, true)
+			changed := fedStatus.update(tc.generation, tc.reason, collectedStatus, collectedResourceStatus, tc.resourceStatusCollection)
 			if tc.expectedChanged != changed {
 				t.Fatalf("Expected changed to be %v, got %v", tc.expectedChanged, changed)
+			}
+		})
+	}
+}
+
+func TestNormalizeStatus(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          CollectedResourceStatus
+		expectedResult *CollectedResourceStatus
+		expectedError  error
+	}{
+		{
+			name:           "CollectedResourceStatus is not modified if StatusMap is nil",
+			input:          CollectedResourceStatus{},
+			expectedResult: &CollectedResourceStatus{},
+		},
+		{
+			name: "CollectedResourceStatus is not modified if StatusMap is empty",
+			input: CollectedResourceStatus{
+				StatusMap: map[string]interface{}{},
+			},
+			expectedResult: &CollectedResourceStatus{
+				StatusMap: map[string]interface{}{},
+			},
+		},
+		{
+			name: "CollectedResourceStatus StatusMap is correctly normalized and numbers are converted to float64",
+			input: CollectedResourceStatus{
+				StatusMap: map[string]interface{}{
+					"number": 1,
+					"string": "value",
+					"complexobj": map[string]int{
+						"one": 1,
+					},
+				},
+			},
+			expectedResult: &CollectedResourceStatus{
+				StatusMap: map[string]interface{}{
+					"number": float64(1),
+					"string": "value",
+					"complexobj": map[string]interface{}{
+						"one": float64(1),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := normalizeStatus(tc.input)
+			if err != tc.expectedError {
+				t.Fatalf("Expected error to be %v, got %v", tc.expectedError, err)
+			}
+
+			if !reflect.DeepEqual(tc.expectedResult, actual) {
+				t.Fatalf("Expected result to be %#v, got %#v", tc.expectedResult, actual)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Federated resources that have target resources without status field are constantly evaluated as "changed", if RawStatusCollection is Enabled. This triggers an infinite loop when multiple FederatedResources are created at the same time in the cluster.
Also, this PR applies to collectedStatuses the same transformation that is applied to the FederatedResource status (json.Marshal - json.Unmarshall), so to prevent avoidable changes (and reconciliations) to the FederatedResources.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1373

**Special notes for your reviewer**:
