### PR TITLE
support retain custom fields for federate resource

### DIFF
--- a/charts/kubefed/crds/crds.yaml
+++ b/charts/kubefed/crds/crds.yaml
@@ -78,6 +78,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -211,6 +215,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -344,6 +352,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               retainReplicas:
                 type: boolean
               template:
@@ -479,6 +491,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -610,6 +626,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -743,6 +763,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -876,6 +900,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               retainReplicas:
                 type: boolean
               template:
@@ -1009,6 +1037,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -1142,6 +1174,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
@@ -1275,6 +1311,10 @@ spec:
                       type: object
                     type: array
                 type: object
+              retainCustomFields:
+                items:
+                  type: string
+                type: array
               template:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -904,9 +904,17 @@ conditional, an explanation will be provided in a subsequent section.
 | All            | metadata.annotations      | Always      | The annotations field is intended to be managed by controllers in member clusters. |
 | All            | metadata.finalizers       | Always      | The finalizers field is intended to be managed by controllers in member clusters.  |
 | All            | metadata.resourceVersion  | Always      | Updates require the most recent resourceVersion for concurrency control.           |
+| All            | custom fields             | Conditional | A controller may be managing this fields.                                          |
 | Scalable       | spec.replicas             | Conditional | The HPA controller may be managing the replica count of a scalable resource.       |
 | Service        | spec.clusterIP,spec.ports | Always      | A controller may be managing these fields.                                         |
 | ServiceAccount | secrets                   | Conditional | A controller may be managing this field.                                           |
+
+### Custom Fields Retention
+For some resources that the cluster controller may be managing some fields,
+retention of these fields is controlled by the `retainCustomFields` field 
+of the federated resource. `retainCustomFields` is a list of the field path.
+For example,  set `retainCustomFields` to `["spec.replicas", "spec.paused"]`,
+then it will retain `spec.replicas` and `spec.paused`.
 
 ### Scalable
 

--- a/pkg/controller/util/constants.go
+++ b/pkg/controller/util/constants.go
@@ -46,6 +46,9 @@ const (
 	ReplicasField       = "replicas"
 	RetainReplicasField = "retainReplicas"
 
+	// Custom fields
+	RetainCustomFields = "retainCustomFields"
+
 	// Template fields
 	TemplateField = "template"
 

--- a/pkg/kubefedctl/enable/validation.go
+++ b/pkg/kubefedctl/enable/validation.go
@@ -129,6 +129,14 @@ func federatedTypeValidationSchema(templateSchema map[string]v1.JSONSchemaProps)
 					},
 				},
 			},
+			"retainCustomFields": {
+				Type: "array",
+				Items: &v1.JSONSchemaPropsOrArray{
+					Schema: &v1.JSONSchemaProps{
+						Type: "string",
+					},
+				},
+			},
 		},
 	})
 	if templateSchema != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Define a list of fields for resource that if they're updated on some cluster won't trigger federation controller to sync and overwrite them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/kubefed/issues/1370

**Special notes for your reviewer**:
