### PR TITLE
bugfix: register workqueue metrics in controller-runtime firstly

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os"
 
+	_ "sigs.k8s.io/controller-runtime/pkg/metrics" // for workqueue metrics registration
+
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	_ "k8s.io/client-go/plugin/pkg/client/auth" // Load all client auth plugins for GCP, Azure, Openstack, etc
 	"k8s.io/component-base/logs"


### PR DESCRIPTION
**What this PR does / why we need it**:
Ref to #1372 , because of importing race as [https://github.com/kubernetes-sigs/kubefed/issues/1372#issuecomment-801732030](https://github.com/kubernetes-sigs/kubefed/issues/1372#issuecomment-801732030), workqueue metrics do not work now.
And this PR try to use an import with highest order to fix this.

**Which issue(s) this PR fixes**:
Fixes #1372 

Signed-off-by: Bruce Ma <brucema19901024@gmail.com>
