### PR TITLE
fix metrics workqueues

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -42,6 +42,4 @@ func main() {
 	}
 }
 
-// Without init, the _ imports do not initialize before app package
-func init() {
-}
+func init() {}

--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -41,3 +41,7 @@ func main() {
 		os.Exit(1) //nolint:gocritic
 	}
 }
+
+// Without init, the _ imports do not initialize before app package
+func init() {
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The metrics workqueues seem to appear randomly for various builds/users. This PR ensures the correct package always loads first. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes-sigs/kubefed/issues/1372

**Special notes for your reviewer**:
ExpediaInc is in the process of getting the CLA signed ASAP. 
