### PR TITLE
use merge-patch on finalizer operations to resolve racing conflicts

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/aggregate_clusterroles.yaml
@@ -51,7 +51,7 @@ rules:
   - list
   - update
   - create
-  - update
+  - patch
   - delete
 - apiGroups:
   - multiclusterdns.kubefed.io
@@ -63,6 +63,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - core.kubefed.io
@@ -74,6 +75,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - types.kubefed.io
@@ -85,6 +87,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/clusterrole.yaml
@@ -17,6 +17,7 @@ rules:
   - watch
   - list
   - update
+  - patch
 - apiGroups:
   - multiclusterdns.kubefed.io
   resources:
@@ -27,6 +28,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - core.kubefed.io
@@ -38,6 +40,7 @@ rules:
   - list
   - create
   - update
+  - patch
 - apiGroups:
   - types.kubefed.io
   resources:
@@ -47,6 +50,7 @@ rules:
   - watch
   - list
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/charts/kubefed/charts/controllermanager/templates/roles.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/roles.yaml
@@ -18,6 +18,7 @@ rules:
   - watch
   - list
   - update
+  - patch
 - apiGroups:
   - multiclusterdns.kubefed.io
   resources:
@@ -28,6 +29,7 @@ rules:
   - list
   - create
   - update
+  - patch
 - apiGroups:
   - core.kubefed.io
   resources:
@@ -38,6 +40,7 @@ rules:
   - list
   - create
   - update
+  - patch
   - delete
 - apiGroups:
   - types.kubefed.io
@@ -48,6 +51,7 @@ rules:
   - watch
   - list
   - update
+  - patch
 - apiGroups:
   - ""
   resources:
@@ -76,6 +80,7 @@ rules:
   - get
   - create
   - update
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/pkg/client/generic/genericclient.go
+++ b/pkg/client/generic/genericclient.go
@@ -34,6 +34,7 @@ type Client interface {
 	Delete(ctx context.Context, obj runtime.Object, namespace, name string, opts ...client.DeleteOption) error
 	List(ctx context.Context, obj runtime.Object, namespace string, opts ...client.ListOption) error
 	UpdateStatus(ctx context.Context, obj runtime.Object) error
+	Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error
 }
 
 type genericClient struct {
@@ -88,4 +89,8 @@ func (c *genericClient) List(ctx context.Context, obj runtime.Object, namespace 
 
 func (c *genericClient) UpdateStatus(ctx context.Context, obj runtime.Object) error {
 	return c.client.Status().Update(ctx, obj)
+}
+
+func (c *genericClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.client.Patch(ctx, obj, patch, opts...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
`Patch` is more efficient than `Update` to handle racing conditions on high-frequency changes of objects, which is also recommended by kubernetes spec.

**Which issue(s) this PR fixes**:
Try to avoid some errors, like [https://github.com/kubernetes-sigs/kubefed/blob/4dbd63b07de4b2bcebf3bd2632e0ec08e254f4c3/pkg/controller/sync/controller.go#L283](https://github.com/kubernetes-sigs/kubefed/blob/4dbd63b07de4b2bcebf3bd2632e0ec08e254f4c3/pkg/controller/sync/controller.go#L283)

