### PR TITLE
fixed false api resource error log in kubefedctl

### DIFF
--- a/pkg/kubefedctl/enable/util.go
+++ b/pkg/kubefedctl/enable/util.go
@@ -135,7 +135,10 @@ func LookupAPIResource(config *rest.Config, key, targetVersion string) (*metav1.
 	}
 
 	if targetResource != nil {
-		klog.Warningf("Api resource found with err %v, and error could ignore.", apierrors.NewAggregate(errs))
+		if len(errs) != 0 {
+			klog.Warningf("Api resource found with err %v, and error could ignore.", apierrors.NewAggregate(errs))
+		}
+		klog.Info("Api resource found.")
 		return targetResource, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR fixes a logging issue when a resource is enabled using the kubefedctl command. The API output is misleading when there are no errors present.
```
W0505 16:55:32.557140   64360 util.go:138] Api resource found with err <nil>, and error could ignore.
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
