### PR TITLE
build: Remove need for TTY when running in Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ on: [pull_request]
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16.5'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,14 +8,18 @@ on:
       - "master"
 
 jobs:
-  test-and-push:
+  push:
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.16.5'
-      - name: Docker push
-        run: |
-          ./hack/verify-docfiles.sh && echo "Skipping build - only doc files have changed!" || \
-            make push
+      
+      - name: Run tests
+        run: DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
+
+      - name: Push Docker images
+        run: make push


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue when running in Github Actions that a TTY is not available so Docker build fails.

**Which issue(s) this PR fixes**
Fixes #

**Special notes for your reviewer**:
I don't know how to test this out without merging if the review is OK.