### PR TITLE
fix: retry on recoverable propagation failure

### DIFF
--- a/pkg/controller/sync/controller.go
+++ b/pkg/controller/sync/controller.go
@@ -450,6 +450,15 @@ func (s *KubeFedSyncController) setFederatedStatus(fedResource FederatedResource
 		return util.StatusError
 	}
 
+	// return Error to trigger a retry with back off on recoverable propagation failure
+	if reason == status.AggregateSuccess {
+		for _, value := range collectedStatus.StatusMap {
+			if status.IsRecoverableError(value) {
+				return util.StatusError
+			}
+		}
+	}
+
 	return util.StatusAllOK
 }
 

--- a/pkg/controller/sync/status/status.go
+++ b/pkg/controller/sync/status/status.go
@@ -164,6 +164,24 @@ func SetFederatedStatus(fedObject *unstructured.Unstructured, reason AggregateRe
 	return true, nil
 }
 
+// IsRecoverableError returns whether the given PropagationStatus is a possibly recoverable error.
+func IsRecoverableError(status PropagationStatus) bool {
+	switch status {
+	case
+		CreationFailed,
+		UpdateFailed,
+		DeletionFailed,
+		LabelRemovalFailed,
+		RetrievalFailed,
+		CreationTimedOut,
+		UpdateTimedOut,
+		DeletionTimedOut,
+		LabelRemovalTimedOut:
+		return true
+	}
+	return false
+}
+
 // update ensures that the status reflects the given generation, reason
 // and collected status. Returns a boolean indication of whether the
 // status has been changed.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently sync controller won't retry propagting a fed resource on any propagation failure, it's not resonable for some recoverable failures such as quota exceed, lack of permissions, etc. For the quota case, after we expand the quota for the failed cluster, we expect KubeFed to automatically succeed in propagating rather than manually edit the fed resource (which is meaninglessly) to trigger a reconciliation.

This PR enable sync controller to retry with back off on recoverable propagation failure.