### PR TITLE
build: Use gh instead of hub CLI for release automation

### DIFF
--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -33,8 +33,8 @@ GITHUB_REPO="${GITHUB_REPO:-kubernetes-sigs/kubefed}"
 GITHUB_REMOTE_UPSTREAM_NAME="${GITHUB_REMOTE_UPSTREAM_NAME:-upstream}"
 
 function verify-command-installed() {
-  if ! util::command-installed jq; then
-    echo "jq command not found. Please add jq to your PATH and try again." >&2
+  if ! util::command-installed gh; then
+    echo "gh command not found. Please add gh to your PATH and try again." >&2
     return 1
   fi
 }
@@ -61,17 +61,17 @@ function create-and-push-tag() {
 }
 
 function build-status() {
-  local buildStatusAPIURL="https://api.github.com/repos/${GITHUB_REPO}/actions/runs?per_page=1&event=push&branch=${RELEASE_TAG}"
-  curl -sH 'Accept: application/vnd.github.v3+json' "${buildStatusAPIURL}" | jq -r '.workflow_runs[0].status'
+  local buildStatusAPIURL="/repos/${GITHUB_REPO}/actions/runs?per_page=1&event=push&branch=${RELEASE_TAG}"
+  gh api --jq '.workflow_runs[0].status' "${buildStatusAPIURL}"
 }
 
 function build-conclusion() {
-  local buildStatusAPIURL="https://api.github.com/repos/${GITHUB_REPO}/actions/runs?per_page=1&event=push&branch=${RELEASE_TAG}"
-  curl -sH 'Accept: application/vnd.github.v3+json' "${buildStatusAPIURL}" | jq -r '.workflow_runs[0].conclusion'
+  local buildStatusAPIURL="/repos/${GITHUB_REPO}/actions/runs?per_page=1&event=push&branch=${RELEASE_TAG}"
+  gh api --jq '.workflow_runs[0].conclusion' "${buildStatusAPIURL}"
 }
 
 function build-started() {
-  if [[ "$(build-status)" == "in-progress" ]]; then
+  if [[ "$(build-status)" == "in_progress" ]]; then
     return 0
   fi
   return 1
@@ -118,7 +118,7 @@ if [[ ! "${RELEASE_TAG}" =~ ${RELEASE_TAG_REGEX} ]]; then
   exit 1
 fi
 
-util::log "Verifying jq CLI command installed"
+util::log "Verifying gh CLI command installed"
 verify-command-installed
 
 util::log "Building release artifacts first to make sure build succeeds"

--- a/scripts/create-gh-release.sh
+++ b/scripts/create-gh-release.sh
@@ -30,15 +30,14 @@ GITHUB_REMOTE_UPSTREAM_NAME="${GITHUB_REMOTE_UPSTREAM_NAME:-upstream}"
 GITHUB_PR_BASE_BRANCH="${GITHUB_PR_BASE_BRANCH:-kubernetes-sigs:master}"
 
 function verify-command-installed() {
-  if ! util::command-installed hub; then
-    echo "hub command not found. Please add hub to your PATH and try again." >&2
+  if ! util::command-installed gh; then
+    echo "gh command not found. Please add gh to your PATH and try again." >&2
     return 1
   fi
 }
 
 function prime-command-for-auth() {
-  # Run valid but benign hub command to prompt user for github auth
-  hub release show -f "%n" v0.1.0-rc5
+  gh auth status
 }
 
 RELEASE_ASSETS_FILE="kubefed-${RELEASE_TAG}-asset-files.txt"
@@ -82,17 +81,14 @@ function create-github-release() {
   local releaseFile="kubefed-${RELEASE_TAG}-github-release.md"
   github-release-template > "${releaseFile}"
 
-  # Build asset attach arguments for hub release command
-  local assetArgs
+  # Build asset attach arguments for gh release command
+  local assetFiles
   for asset in $(cat "${RELEASE_ASSETS_FILE}"); do
-    assetArgs+="--attach ${asset} "
+    assetFiles+=" ${asset} "
   done
 
-  # Remove trailing whitespace
-  assetArgs="$(echo ${assetArgs})"
-
   # TODO(font): Add draft and prerelease options to this script.
-  hub release create --draft --prerelease ${assetArgs} -F "${releaseFile}" "${RELEASE_TAG}"
+  gh release create --draft --prerelease -F "${releaseFile}" "${RELEASE_TAG}" "${assetFiles}"
 }
 
 # TODO(font): Consider performing this step BEFORE tagging and pushing a new
@@ -100,11 +96,11 @@ function create-github-release() {
 function create-release-pr() {
   local commitFiles="${ROOT_DIR}/CHANGELOG.md ${ROOT_DIR}/charts/index.yaml"
 
-  # Use the origin and upstream git remote convention names used by hub.
+  # Use the origin and upstream git remote convention names used by gh.
   git checkout -b "${RELEASE_TAG}-rel" --no-track "${GITHUB_REMOTE_UPSTREAM_NAME}/master"
   git commit ${commitFiles} -m "Update repo for release ${RELEASE_TAG}"
   git push --set-upstream "${GITHUB_REMOTE_FORK_NAME}" "${RELEASE_TAG}-rel"
-  PR_URL="$(hub pull-request --base "${GITHUB_PR_BASE_BRANCH}" -m "Update repo for release ${RELEASE_TAG}")"
+  PR_URL="$(gh pr create --base "${GITHUB_PR_BASE_BRANCH}" --title "Update repo for release ${RELEASE_TAG}" -b "" --fill)"
 
 }
 
@@ -113,10 +109,10 @@ if [[ ! "${RELEASE_TAG}" =~ ${RELEASE_TAG_REGEX} ]]; then
   exit 1
 fi
 
-util::log "Verifying hub CLI command installed"
+util::log "Verifying gh CLI command installed"
 verify-command-installed
 
-util::log "Priming hub CLI command for authentication"
+util::log "Priming gh CLI command for authentication"
 prime-command-for-auth
 
 util::log "Verifying release assets file exists"
@@ -130,4 +126,4 @@ create-github-release
 
 echo -e "\nCreated kubefed ${RELEASE_TAG} pull request and github draft release. Go merge and publish at the following URLs when ready:"
 echo "${PR_URL}"
-hub release show --format "%U%n" "${RELEASE_TAG}"
+gh release view --json url --jq .url "${RELEASE_TAG}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Switch to `gh` from `hub`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I've just used these scripts to release v0.8.0 so they are verified to be working :tada: 