### PR TITLE
fix: Support Kubernetes pre-release versions in kubefed chart

### DIFF
--- a/charts/kubefed/Chart.yaml
+++ b/charts/kubefed/Chart.yaml
@@ -2,9 +2,10 @@ apiVersion: v2
 description: KubeFed helm chart
 name: kubefed
 version: 0.0.3
-kubeVersion: ">= 1.16.0"
+kubeVersion: ">= 1.16.0-0"
 dependencies:
 - name: controllermanager
   version: 0.0.3
   repository: "https://localhost/" # Required but unused.
   condition: controllermanager.enabled
+


### PR DESCRIPTION
This fixes support to deploy on EKS.
