### PR TITLE
chore: Bump golang from 1.16.5 to 1.16.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.5'
+          go-version: '^1.16.6'
 
       - name: Run tests
         run: |

--- a/.github/workflows/test-and-push.yml
+++ b/.github/workflows/test-and-push.yml
@@ -16,8 +16,8 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '^1.16.5'
-      
+          go-version: '^1.16.6'
+
       - name: Run tests
         run: DOWNLOAD_BINARIES=y bash -x ./scripts/pre-commit.sh
 

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ endif
 BUILDMNT = /go/src/$(GOTARGET)
 # The version here should match the version of go configured in
 # .github/workflows files.
-BUILD_IMAGE ?= golang:1.16.5
+BUILD_IMAGE ?= golang:1.16.6
 
 HYPERFED_TARGET = bin/hyperfed
 CONTROLLER_TARGET = bin/controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Bumps golang version to latest.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
