### PR TITLE
bump webhook version to v1

### DIFF
--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -18,9 +18,9 @@ metadata:
     cert-manager.io/inject-ca-from: {{ printf "%s/%s%s" .Release.Namespace .Release.Name "-root-certificate" | quote }}
   {{- end }}
 webhooks:
-- name: federatedtypeconfigs.core.kubefed.io
-  admissionReviewVersions:
-    - v1
+- admissionReviewVersions:
+  - v1beta1
+  name: federatedtypeconfigs.core.kubefed.io
   clientConfig:
     service:
       namespace: {{ .Release.Namespace | quote }}
@@ -53,9 +53,9 @@ webhooks:
     matchLabels:
       name: {{ .Release.Namespace }}
 {{ end }}
-- name: kubefedclusters.core.kubefed.io
-  admissionReviewVersions:
-    - v1
+- admissionReviewVersions:
+  - v1beta1
+  name: kubefedclusters.core.kubefed.io
   clientConfig:
     service:
       namespace: {{ .Release.Namespace | quote }}
@@ -83,9 +83,9 @@ webhooks:
     matchLabels:
       name: {{ .Release.Namespace }}
 {{ end }}
-- name: kubefedconfigs.core.kubefed.io
-  admissionReviewVersions:
-    - v1
+- admissionReviewVersions:
+  - v1beta1
+  name: kubefedconfigs.core.kubefed.io
   clientConfig:
     service:
       namespace: {{ .Release.Namespace | quote }}
@@ -124,9 +124,9 @@ metadata:
   name: mutation.core.kubefed.io
 {{- end }}
 webhooks:
-- name: kubefedconfigs.core.kubefed.io
-  admissionReviewVersions:
-    - v1
+- admissionReviewVersions:
+  - v1beta1
+  name: kubefedconfigs.core.kubefed.io
   clientConfig:
     service:
       namespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
Signed-off-by: yuswift <yuswift2018@gmail.com>



**What this PR does / why we need it**:
To support v1.22, we need to bump webhook version to v1.
ref https://github.com/kubernetes-sigs/kubefed/issues/1445
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
