### PR TITLE
Used standard bash redirection for avoiding the use of deprecated klogs

### DIFF
--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -81,7 +81,7 @@ EOF
 ${ROOT_DIR}/bin/etcd --data-dir ${WORKDIR} --log-output stdout > ${WORKDIR}/etcd.log 2>&1 &
 util::wait-for-condition 'etcd' "curl http://127.0.0.1:2379/version &> /dev/null" 30
 
-${ROOT_DIR}/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir=${WORKDIR} --log-file=${WORKDIR}/kube-apiserver.log --logtostderr=false 2> /dev/null &
+${ROOT_DIR}/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir=${WORKDIR} 2> ${WORKDIR}/kube-apiserver.log &
 util::wait-for-condition 'kube-apiserver' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context kubefed get --raw=/healthz &> /dev/null" 60
 
 # Generate YAML templates to enable resource propagation for helm chart.


### PR DESCRIPTION
…gFlags

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Used standard bash redirection for avoiding the use of deprecated klogs. In this case they were `--log-file` and `--logtostderr`.
**Which issue(s) this PR fixes** 
Fixes #1470 

**Special notes for your reviewer**:
