### PR TITLE
Enabled to specify namespace in FederatedTypeConfig.

### DIFF
--- a/charts/kubefed/templates/federatedtypeconfig.yaml
+++ b/charts/kubefed/templates/federatedtypeconfig.yaml
@@ -3,6 +3,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: clusterroles.rbac.authorization.k8s.io
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -22,6 +23,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: configmaps
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -40,6 +42,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: deployments.apps
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -59,6 +62,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: ingresses.extensions
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -78,6 +82,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: jobs.batch
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -97,6 +102,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: namespaces
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -115,6 +121,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: replicasets.apps
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -134,6 +141,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: secrets
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -152,6 +160,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: serviceaccounts
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io
@@ -170,6 +179,7 @@ apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
   name: services
+  namespace: {{ .Release.Namespace }}
 spec:
   federatedType:
     group: types.kubefed.io


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I want to be able to specify a namespace with FederatedTypeConfig.
This is because the namespace is not given to FederatedTypeConfig even if the following command is executed.
```sh
$ helm template kubefed charts/kubefed --namespace kube-federation-system
```