### PR TITLE
Fix mutatingwebhookconfiguration CA cert when cert-manager is enabled

### DIFF
--- a/charts/kubefed/Chart.yaml
+++ b/charts/kubefed/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
 description: KubeFed helm chart
 name: kubefed
-version: 0.0.4
+version: 0.0.5
 kubeVersion: ">= 1.16.0-0"
 dependencies:
 - name: controllermanager
-  version: 0.0.4
+  version: 0.0.5
   repository: "https://localhost/" # Required but unused.
   condition: controllermanager.enabled
 

--- a/charts/kubefed/charts/controllermanager/Chart.yaml
+++ b/charts/kubefed/charts/controllermanager/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: "0.8.1"
 description: A Helm chart for KubeFed Controller Manager
 name: controllermanager
-version: 0.0.4
+version: 0.0.5

--- a/charts/kubefed/charts/controllermanager/templates/webhook.yaml
+++ b/charts/kubefed/charts/controllermanager/templates/webhook.yaml
@@ -123,6 +123,10 @@ metadata:
 {{- else }}
   name: mutation.core.kubefed.io
 {{- end }}
+  annotations:
+  {{- if .Values.certManager.enabled }}
+    cert-manager.io/inject-ca-from: {{ printf "%s/%s%s" .Release.Namespace .Release.Name "-root-certificate" | quote }}
+  {{- end }}
 webhooks:
 - name: kubefedconfigs.core.kubefed.io
   admissionReviewVersions:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes the issue of the missing `caBundle` configuration property on `MutatingWebhookConfiguration` when `kubefed` is instaleld with `cert-manager` enabled.

Example error:

```
Error from server (InternalError): error when creating "kubefedconfig.yaml": Internal error occurred: failed calling webhook "kubefedconfigs.core.kubefed.io": Post "https://kubefed-admission-webhook.kube-federation-system.svc:443/default-kubefedconfig?timeout=10s": x509: certificate signed by unknown authority
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
