### PR TITLE
fix: updating scripts to be used on quickstart

### DIFF
--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -67,6 +67,7 @@ curl "${curl_args}" "${golint_url}" \
 
 # Install go-bindata tool
 pushd ${root_dir}/tools
+go get -u github.com/go-bindata/go-bindata/...
 GOBIN=${dest_dir} go install github.com/go-bindata/go-bindata/v3/go-bindata
 popd
 

--- a/scripts/fix-joined-kind-clusters.sh
+++ b/scripts/fix-joined-kind-clusters.sh
@@ -45,7 +45,7 @@ do
   if [[ "${LOCAL_TESTING}" ]]; then
     ENDPOINT="$(kubectl config view -o jsonpath='{.clusters[?(@.name == "'"${cluster}"'")].cluster.server}')"
   else
-    IP_ADDR="$(docker inspect -f "${INSPECT_PATH}" "${cluster}-control-plane")"
+    IP_ADDR="$(docker inspect -f "${INSPECT_PATH}" "kind-control-plane")"
     ENDPOINT="https://${IP_ADDR}:6443"
   fi
   kubectl patch kubefedclusters -n "${NS}" "${cluster}" --type merge \


### PR DESCRIPTION
on macOS

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Add an entry to CHANGELOG.md if the PR represents a user-visible change.
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This should resolve this issue for macOS users for this:
https://github.com/kubernetes-sigs/kubefed/issues/1494

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1494
[issue 1494](https://github.com/kubernetes-sigs/kubefed/issues/1494)

**Special notes for your reviewer**:
I've tested this on my machine and it works for me, and I've started from scratch a few times and have encountered the same issue. So, I don't think it's isolated to me, but perhaps there is a docker version/macOS version thing that could be hanging this up. I do know this fixes the issues I encountered.