### PR TITLE
fix: Use specific service account token secret for join

### DIFF
--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -526,7 +526,7 @@ func createServiceAccount(clusterClientset kubeclient.Interface, namespace,
 	}
 }
 
-// createServiceAccount creates a service account in the cluster associated
+// createServiceAccountTokenSecret creates a service account token secret in the cluster associated
 // with clusterClientset with credentials that will be used by the host cluster
 // to access its API server.
 func createServiceAccountTokenSecret(saName string, clusterClientset kubeclient.Interface, namespace,

--- a/pkg/kubefedctl/util/util.go
+++ b/pkg/kubefedctl/util/util.go
@@ -107,6 +107,12 @@ func ClusterServiceAccountName(joiningClusterName, hostClusterName string) strin
 	return fmt.Sprintf("%s-%s", joiningClusterName, hostClusterName)
 }
 
+// ClusterServiceAccountTokenName returns the name of a service account token secret whose
+// credentials are used by the host cluster to access the client cluster.
+func ClusterServiceAccountTokenSecretName(joiningClusterName, hostClusterName string) string {
+	return fmt.Sprintf("%s-%s", joiningClusterName, hostClusterName)
+}
+
 // RoleName returns the name of a Role or ClusterRole and its
 // associated RoleBinding or ClusterRoleBinding that are used to allow
 // the service account to access necessary resources on the cluster.

--- a/pkg/kubefedctl/util/util.go
+++ b/pkg/kubefedctl/util/util.go
@@ -107,7 +107,7 @@ func ClusterServiceAccountName(joiningClusterName, hostClusterName string) strin
 	return fmt.Sprintf("%s-%s", joiningClusterName, hostClusterName)
 }
 
-// ClusterServiceAccountTokenName returns the name of a service account token secret whose
+// ClusterServiceAccountTokenSecretName returns the name of a service account token secret whose
 // credentials are used by the host cluster to access the client cluster.
 func ClusterServiceAccountTokenSecretName(joiningClusterName, hostClusterName string) string {
 	return fmt.Sprintf("%s-%s", joiningClusterName, hostClusterName)


### PR DESCRIPTION
With `LegacyServiceAccountTokenNoAutoGeneration` feature graduating to beta in
k8s v1.24, a token is not automatically generated when a service account is created.
This commit fixes this by requesting a specific service token account secret which
is populated by the token controller. This is backwards compatible with previous
versions of Kubernetes.