### PR TITLE
fix: Wait for SA token to be populated

### DIFF
--- a/pkg/kubefedctl/join.go
+++ b/pkg/kubefedctl/join.go
@@ -904,6 +904,10 @@ func populateSecretInHostCluster(clusterClientset, hostClientset kubeclient.Inte
 			return false, nil
 		}
 
+		if _, ok := joiningClusterSASecret.Data[ctlutil.TokenKey]; !ok {
+			return false, nil
+		}
+
 		secret = joiningClusterSASecret
 
 		return true, nil


### PR DESCRIPTION
Although normally very fast, generation of the SA token is async so poll
the SA token until it exists.
