### PR TITLE
build: Use KinD for syncing helm chart resources

### DIFF
--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -78,3 +78,5 @@ echo -n "#   kubebuilder:    "; "${dest_dir}/kubebuilder" version
 echo -n "#   helm:           "; "${dest_dir}/helm" version --client --short
 echo -n "#   golangci-lint:  "; "${dest_dir}/golangci-lint" --version
 echo -n "#   go-bindata:     "; "${dest_dir}/go-bindata" -version
+
+"${root_dir}/scripts/download-e2e-binaries.sh"

--- a/scripts/sync-up-helm-chart.sh
+++ b/scripts/sync-up-helm-chart.sh
@@ -22,9 +22,12 @@ source "$(dirname "${BASH_SOURCE}")/util.sh"
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." ; pwd)"
 WORKDIR=$(mktemp -d)
+trap-add 'rm -rf "${WORKDIR}"' EXIT
 NS="${KUBEFED_NAMESPACE:-kube-federation-system}"
 CHART_FEDERATED_PROPAGATION_DIR="${CHART_FEDERATED_PROPAGATION_DIR:-charts/kubefed}"
 TEMP_CRDS_YAML="/tmp/kubefed-crds.yaml"
+
+export PATH=${ROOT_DIR}/bin:${PATH}
 
 OS=`uname`
 SED=sed
@@ -34,13 +37,6 @@ if [ "${OS}" == "Darwin" ];then
     exit 1
   fi
   SED=gsed
-fi
-
-# Check for existence of kube-apiserver and etcd binaries in bin directory
-if [[ ! -f ${ROOT_DIR}/bin/etcd || ! -f ${ROOT_DIR}/bin/kube-apiserver ]];
-then
-  echo "Missing 'etcd' and/or 'kube-apiserver' binaries in bin directory. Call './scripts/download-binaries.sh' to download them first"
-  exit 1
 fi
 
 # Remove existing generated crds to ensure that stale content doesn't linger.
@@ -59,30 +55,9 @@ done
 
 mv ${TEMP_CRDS_YAML} ./charts/kubefed/charts/controllermanager/crds/crds.yaml
 
-# Generate kubeconfig to access kube-apiserver. It is cleaned when script is done.
-cat <<EOF > ${WORKDIR}/kubeconfig
-apiVersion: v1
-clusters:
-- cluster:
-    server: 127.0.0.1:8080
-  name: development
-contexts:
-- context:
-    cluster: development
-    user: ""
-  name: kubefed
-current-context: ""
-kind: Config
-preferences: {}
-users: []
-EOF
-
-# Start kube-apiserver to generate CRDs
-${ROOT_DIR}/bin/etcd --data-dir ${WORKDIR} --log-output stdout > ${WORKDIR}/etcd.log 2>&1 &
-util::wait-for-condition 'etcd' "curl http://127.0.0.1:2379/version &> /dev/null" 30
-
-${ROOT_DIR}/bin/kube-apiserver --etcd-servers=http://127.0.0.1:2379 --service-cluster-ip-range=10.0.0.0/16 --cert-dir=${WORKDIR} 2> ${WORKDIR}/kube-apiserver.log &
-util::wait-for-condition 'kube-apiserver' "kubectl --kubeconfig ${WORKDIR}/kubeconfig --context kubefed get --raw=/healthz &> /dev/null" 60
+declare -rx KUBECONFIG="${WORKDIR}/kubeconfig"
+kind create cluster --name=kubefed-dev
+trap-add 'kind delete cluster --name=kubefed-dev' EXIT
 
 # Generate YAML templates to enable resource propagation for helm chart.
 echo -n > ${CHART_FEDERATED_PROPAGATION_DIR}/templates/federatedtypeconfig.yaml
@@ -90,7 +65,7 @@ echo -n > ${CHART_FEDERATED_PROPAGATION_DIR}/crds/crds.yaml
 for filename in ./config/enabletypedirectives/*.yaml; do
   full_name=${CHART_FEDERATED_PROPAGATION_DIR}/templates/$(basename $filename)
 
-  ./bin/kubefedctl --kubeconfig ${WORKDIR}/kubeconfig enable -f "${filename}" --kubefed-namespace="${NS}" --host-cluster-context kubefed -o yaml > ${full_name}
+  ./bin/kubefedctl --kubeconfig ${WORKDIR}/kubeconfig enable -f "${filename}" --kubefed-namespace="${NS}" -o yaml > ${full_name}
   $SED -n '/^---/,/^---/p' ${full_name} >> ${CHART_FEDERATED_PROPAGATION_DIR}/templates/federatedtypeconfig.yaml
   $SED -i '$d' ${CHART_FEDERATED_PROPAGATION_DIR}/templates/federatedtypeconfig.yaml
 
@@ -101,7 +76,4 @@ for filename in ./config/enabletypedirectives/*.yaml; do
 done
 
 # Clean kube-apiserver daemons and temporary files
-kill %1 # etcd
-kill %2 # kube-apiserver
-rm -fr ${WORKDIR}
 echo "Helm chart synced successfully"

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -119,3 +119,10 @@ function check-command-installed() {
     exit 1
   }
 }
+
+trap-add() {
+  local sig="${2:?Signal required}"
+  hdls="$(trap -p "${sig}" | cut -f2 -d \')"
+  # shellcheck disable=SC2064 # Quotes are required here to properly expand when adding the new trap.
+  trap "${hdls}${hdls:+;}${1:?Handler required}" "${sig}"
+}


### PR DESCRIPTION
Previously this was using kubebuilder provided API server and etcd, but these were very out of date (k8s v1.16), leading to potentially out of date resources and difficulties upgrading to later APIs that were not available in v1.16 (e.g. `networking.k8s.io/v1`).

This commit fixes this by using KinD as the cluster to discover resources to
sync to the Helm chart.
