### PR TITLE
build: Use setup-envtest to download later version of envtest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,9 @@ all: container hyperfed controller kubefedctl webhook e2e
 
 # Unit tests
 test:
-	go test $(TEST_PKGS)
+	go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	source <(setup-envtest use -p env 1.21.x) && \
+		go test $(TEST_PKGS)
 
 build: hyperfed controller kubefedctl webhook
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,16 +34,26 @@ help you get started.
 ### Binaries
 
 The KubeFed deployment depends on `kubebuilder`, `etcd`, `kubectl`, and
-`kube-apiserver` >= v1.16 being installed in the path. The `kubebuilder`
-([v2.3.1](https://github.com/kubernetes-sigs/kubebuilder/releases/tag/v2.3.1)
-as of this writing) release packages all of these dependencies together.
+`kube-apiserver` >= v1.21. The `kubebuilder` release packages all of these
+dependencies together and the `controller-runtime` project contains a helper
+utility called `setup-envtest` that downloads required binaries and can also
+set up required environment variables (especially `KUBEBUILDER_ASSETS`).
 
 These binaries can be installed via the `download-binaries.sh` script, which
 downloads them to `./bin`:
 
 ```bash
 ./scripts/download-binaries.sh
+```
+
+Running make targets will ensure that the `PATH` and other environment variables
+are correctly configured for the build itself, but if you wish to configure your
+local shell in the same way then run the following commands after running the
+`download-binaries.sh` script above:
+
+```bash
 export PATH=$(pwd)/bin:${PATH}
+source <(setup-envtest use -p env 1.21.x)
 ```
 
 ### kubernetes

--- a/scripts/download-binaries.sh
+++ b/scripts/download-binaries.sh
@@ -49,14 +49,28 @@ kb_url="https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kb_v
 curl "${curl_args}" "${kb_url}" \
   | tar xzP -C "${dest_dir}" --strip-components=2
 
-export KUBEBUILDER_ASSETS="${dest_dir}"
-echo "Setting to KUBEBUILDER_ASSETS ${dest_dir}"
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+source <(setup-envtest use -p env 1.21.x)
+
+echo "KUBEBUILDER_ASSETS is set to ${KUBEBUILDER_ASSETS}"
 
 helm_version="3.6.0"
 helm_tgz="helm-v${helm_version}-${platform}-amd64.tar.gz"
 helm_url="https://get.helm.sh/$helm_tgz"
 curl "${curl_args}" "${helm_url}" \
     | tar xzP -C "${dest_dir}" --strip-components=1 "${platform}-amd64/helm"
+
+kubectl_version="v1.21.14"
+curl -Lo "${dest_dir}/kubectl" "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/amd64/kubectl"
+(cd "${dest_dir}" && \
+ echo "$(curl -L "https://dl.k8s.io/release/${kubectl_version}/bin/${platform}/amd64/kubectl.sha256")  kubectl" | \
+   sha256sum --check
+)
+chmod +x "${dest_dir}/kubectl"
+
+kubebuilder_version="2.3.2"
+curl -L https://github.com/kubernetes-sigs/kubebuilder/releases/download/v${kubebuilder_version}/kubebuilder_${kubebuilder_version}_${platform}_amd64.tar.gz | \
+  tar xzP -C "${dest_dir}" --strip-components=2 -- "kubebuilder_${kubebuilder_version}_${platform}_amd64/bin/kubebuilder"
 
 golint_version="1.40.1"
 golint_dir="golangci-lint-${golint_version}-${platform}-amd64"


### PR DESCRIPTION
`controller-runtime` provides a convenient tool to download various versions of k8s. This commit switches to using that to ensure we use a single version for testing in unit tests and in e2e tests, namely v1.21.x right now so to keep the version stable while just changing the installation mechanism.
