### PR TITLE
fix: Move ingress from extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/charts/kubefed/templates/federatedtypeconfig.yaml
+++ b/charts/kubefed/templates/federatedtypeconfig.yaml
@@ -58,7 +58,7 @@ spec:
 apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig
 metadata:
-  name: ingresses.extensions
+  name: ingresses.networking.k8s.io
 spec:
   federatedType:
     group: types.kubefed.io
@@ -68,11 +68,11 @@ spec:
     version: v1beta1
   propagation: Enabled
   targetType:
-    group: extensions
+    group: networking.k8s.io
     kind: Ingress
     pluralName: ingresses
     scope: Namespaced
-    version: v1beta1
+    version: v1
 ---
 apiVersion: core.kubefed.io/v1beta1
 kind: FederatedTypeConfig

--- a/config/enabletypedirectives/ingresses.networking.k8s.io.yaml
+++ b/config/enabletypedirectives/ingresses.networking.k8s.io.yaml
@@ -1,4 +1,4 @@
 apiVersion: core.kubefed.io/v1beta1
 kind: EnableTypeDirective
 metadata:
-  name: ingresses.extensions
+  name: ingresses.networking.k8s.io

--- a/test/common/bindata.go
+++ b/test/common/bindata.go
@@ -20,7 +20,7 @@ limitations under the License.
 // test/common/fixtures/clusterroles.rbac.authorization.k8s.io.yaml
 // test/common/fixtures/configmaps.yaml
 // test/common/fixtures/deployments.apps.yaml
-// test/common/fixtures/ingresses.extensions.yaml
+// test/common/fixtures/ingresses.networking.k8s.io.yaml
 // test/common/fixtures/jobs.batch.yaml
 // test/common/fixtures/namespaces.yaml
 // test/common/fixtures/replicasets.apps.yaml
@@ -31,7 +31,7 @@ limitations under the License.
 // config/enabletypedirectives/clusterroles.rbac.authorization.k8s.io.yaml
 // config/enabletypedirectives/configmaps.yaml
 // config/enabletypedirectives/deployments.apps.yaml
-// config/enabletypedirectives/ingresses.extensions.yaml
+// config/enabletypedirectives/ingresses.networking.k8s.io.yaml
 // config/enabletypedirectives/jobs.batch.yaml
 // config/enabletypedirectives/namespaces.yaml
 // config/enabletypedirectives/replicasets.apps.yaml
@@ -182,25 +182,27 @@ func testCommonFixturesDeploymentsAppsYaml() (*asset, error) {
 	return a, nil
 }
 
-var _testCommonFixturesIngressesExtensionsYaml = []byte(`kind: fixture
+var _testCommonFixturesIngressesNetworkingK8sIoYaml = []byte(`kind: fixture
 template:
   spec:
-    backend:
-      serviceName: testsvc
-      servicePort: 80
+    defaultBackend:
+      service:
+        name: testsvc
+        port:
+          number: 80
 `)
 
-func testCommonFixturesIngressesExtensionsYamlBytes() ([]byte, error) {
-	return _testCommonFixturesIngressesExtensionsYaml, nil
+func testCommonFixturesIngressesNetworkingK8sIoYamlBytes() ([]byte, error) {
+	return _testCommonFixturesIngressesNetworkingK8sIoYaml, nil
 }
 
-func testCommonFixturesIngressesExtensionsYaml() (*asset, error) {
-	bytes, err := testCommonFixturesIngressesExtensionsYamlBytes()
+func testCommonFixturesIngressesNetworkingK8sIoYaml() (*asset, error) {
+	bytes, err := testCommonFixturesIngressesNetworkingK8sIoYamlBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "test/common/fixtures/ingresses.extensions.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "test/common/fixtures/ingresses.networking.k8s.io.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -485,23 +487,23 @@ func configEnabletypedirectivesDeploymentsAppsYaml() (*asset, error) {
 	return a, nil
 }
 
-var _configEnabletypedirectivesIngressesExtensionsYaml = []byte(`apiVersion: core.kubefed.io/v1beta1
+var _configEnabletypedirectivesIngressesNetworkingK8sIoYaml = []byte(`apiVersion: core.kubefed.io/v1beta1
 kind: EnableTypeDirective
 metadata:
-  name: ingresses.extensions
+  name: ingresses.networking.k8s.io
 `)
 
-func configEnabletypedirectivesIngressesExtensionsYamlBytes() ([]byte, error) {
-	return _configEnabletypedirectivesIngressesExtensionsYaml, nil
+func configEnabletypedirectivesIngressesNetworkingK8sIoYamlBytes() ([]byte, error) {
+	return _configEnabletypedirectivesIngressesNetworkingK8sIoYaml, nil
 }
 
-func configEnabletypedirectivesIngressesExtensionsYaml() (*asset, error) {
-	bytes, err := configEnabletypedirectivesIngressesExtensionsYamlBytes()
+func configEnabletypedirectivesIngressesNetworkingK8sIoYaml() (*asset, error) {
+	bytes, err := configEnabletypedirectivesIngressesNetworkingK8sIoYamlBytes()
 	if err != nil {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "config/enabletypedirectives/ingresses.extensions.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	info := bindataFileInfo{name: "config/enabletypedirectives/ingresses.networking.k8s.io.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -687,7 +689,7 @@ var _bindata = map[string]func() (*asset, error){
 	"test/common/fixtures/clusterroles.rbac.authorization.k8s.io.yaml":        testCommonFixturesClusterrolesRbacAuthorizationK8sIoYaml,
 	"test/common/fixtures/configmaps.yaml":                                    testCommonFixturesConfigmapsYaml,
 	"test/common/fixtures/deployments.apps.yaml":                              testCommonFixturesDeploymentsAppsYaml,
-	"test/common/fixtures/ingresses.extensions.yaml":                          testCommonFixturesIngressesExtensionsYaml,
+	"test/common/fixtures/ingresses.networking.k8s.io.yaml":                   testCommonFixturesIngressesNetworkingK8sIoYaml,
 	"test/common/fixtures/jobs.batch.yaml":                                    testCommonFixturesJobsBatchYaml,
 	"test/common/fixtures/namespaces.yaml":                                    testCommonFixturesNamespacesYaml,
 	"test/common/fixtures/replicasets.apps.yaml":                              testCommonFixturesReplicasetsAppsYaml,
@@ -698,7 +700,7 @@ var _bindata = map[string]func() (*asset, error){
 	"config/enabletypedirectives/clusterroles.rbac.authorization.k8s.io.yaml": configEnabletypedirectivesClusterrolesRbacAuthorizationK8sIoYaml,
 	"config/enabletypedirectives/configmaps.yaml":                             configEnabletypedirectivesConfigmapsYaml,
 	"config/enabletypedirectives/deployments.apps.yaml":                       configEnabletypedirectivesDeploymentsAppsYaml,
-	"config/enabletypedirectives/ingresses.extensions.yaml":                   configEnabletypedirectivesIngressesExtensionsYaml,
+	"config/enabletypedirectives/ingresses.networking.k8s.io.yaml":            configEnabletypedirectivesIngressesNetworkingK8sIoYaml,
 	"config/enabletypedirectives/jobs.batch.yaml":                             configEnabletypedirectivesJobsBatchYaml,
 	"config/enabletypedirectives/namespaces.yaml":                             configEnabletypedirectivesNamespacesYaml,
 	"config/enabletypedirectives/replicasets.apps.yaml":                       configEnabletypedirectivesReplicasetsAppsYaml,
@@ -753,7 +755,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"clusterroles.rbac.authorization.k8s.io.yaml": &bintree{configEnabletypedirectivesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
 			"configmaps.yaml":                             &bintree{configEnabletypedirectivesConfigmapsYaml, map[string]*bintree{}},
 			"deployments.apps.yaml":                       &bintree{configEnabletypedirectivesDeploymentsAppsYaml, map[string]*bintree{}},
-			"ingresses.extensions.yaml":                   &bintree{configEnabletypedirectivesIngressesExtensionsYaml, map[string]*bintree{}},
+			"ingresses.networking.k8s.io.yaml":            &bintree{configEnabletypedirectivesIngressesNetworkingK8sIoYaml, map[string]*bintree{}},
 			"jobs.batch.yaml":                             &bintree{configEnabletypedirectivesJobsBatchYaml, map[string]*bintree{}},
 			"namespaces.yaml":                             &bintree{configEnabletypedirectivesNamespacesYaml, map[string]*bintree{}},
 			"replicasets.apps.yaml":                       &bintree{configEnabletypedirectivesReplicasetsAppsYaml, map[string]*bintree{}},
@@ -769,7 +771,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"clusterroles.rbac.authorization.k8s.io.yaml": &bintree{testCommonFixturesClusterrolesRbacAuthorizationK8sIoYaml, map[string]*bintree{}},
 				"configmaps.yaml":                             &bintree{testCommonFixturesConfigmapsYaml, map[string]*bintree{}},
 				"deployments.apps.yaml":                       &bintree{testCommonFixturesDeploymentsAppsYaml, map[string]*bintree{}},
-				"ingresses.extensions.yaml":                   &bintree{testCommonFixturesIngressesExtensionsYaml, map[string]*bintree{}},
+				"ingresses.networking.k8s.io.yaml":            &bintree{testCommonFixturesIngressesNetworkingK8sIoYaml, map[string]*bintree{}},
 				"jobs.batch.yaml":                             &bintree{testCommonFixturesJobsBatchYaml, map[string]*bintree{}},
 				"namespaces.yaml":                             &bintree{testCommonFixturesNamespacesYaml, map[string]*bintree{}},
 				"replicasets.apps.yaml":                       &bintree{testCommonFixturesReplicasetsAppsYaml, map[string]*bintree{}},

--- a/test/common/fixtures/ingresses.extensions.yaml
+++ b/test/common/fixtures/ingresses.extensions.yaml
@@ -1,6 +1,0 @@
-kind: fixture
-template:
-  spec:
-    backend:
-      serviceName: testsvc
-      servicePort: 80

--- a/test/common/fixtures/ingresses.networking.k8s.io.yaml
+++ b/test/common/fixtures/ingresses.networking.k8s.io.yaml
@@ -1,0 +1,8 @@
+kind: fixture
+template:
+  spec:
+    defaultBackend:
+      service:
+        name: testsvc
+        port:
+          number: 80


### PR DESCRIPTION
`extensions/v1beta1` was deprecated in v1.14,
`networking.k8s.io/v1beta1` was deprecated in v1.19 so this commit moves
straight to `networking.k8s.io/v1` which has been available since v1.19.
Considering k8s is now at v1.24.3 this is a sufficient compatibility
window.
