### PR TITLE
feat: add support for arm64 darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ bindir:
 	mkdir -p $(BIN_DIR)
 
 COMMANDS := $(HYPERFED_TARGET) $(CONTROLLER_TARGET) $(KUBEFEDCTL_TARGET) $(WEBHOOK_TARGET)
-PLATFORMS := linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64
+PLATFORMS := linux-amd64 linux-arm64 linux-ppc64le linux-s390x darwin-amd64 darwin-arm64
 ALL_BINS :=
 
 define PLATFORM_template


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for building for darwin-arm64 (MacOS M1/M2 a.k.a ARM laptops)

Fixes #

**Special notes for your reviewer**:
